### PR TITLE
Add font_family field to content text items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Text content items**: `font_family` field to specify custom fonts (default: "Arial")
+
 ## [0.12.0] - 2026-02-14
 
 ### Added

--- a/docs/yaml-api.md
+++ b/docs/yaml-api.md
@@ -218,6 +218,7 @@ Content items define the visual elements within each screenshot.
   gradient: object?          # Text gradient (see Gradient Configuration below)
   
   weight: string?            # "normal" or "bold" (default: "normal")
+  font_family: string?       # Font family name (default: "Arial")
   alignment: string?         # "left", "center", "right" (default: "center")
   
   # Stroke Options (optional):

--- a/src/koubou/config.py
+++ b/src/koubou/config.py
@@ -329,6 +329,7 @@ class ContentItem(BaseModel):
     )
 
     weight: Optional[str] = Field(default="normal", description="Font weight")
+    font_family: Optional[str] = Field(default="Arial", description="Font family name")
     alignment: Optional[str] = Field(
         default="center", description="Text alignment (left, center, right)"
     )

--- a/src/koubou/generator.py
+++ b/src/koubou/generator.py
@@ -1018,6 +1018,7 @@ class ScreenshotGenerator:
                         position=position,
                         font_size=item.size or 24,
                         font_weight=getattr(item, "weight", "normal") or "normal",
+                        font_family=getattr(item, "font_family", "Arial") or "Arial",
                         color=item.color,  # Don't default to black if gradient
                         # is provided
                         gradient=item.gradient,  # Pass gradient configuration

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,6 +136,32 @@ class TestScreenshotConfig:
             )
 
 
+class TestContentItemFontFamily:
+    """Tests for ContentItem font_family field."""
+
+    def test_font_family_default(self):
+        item = ContentItem(type="text", content="Hello", position=("50%", "50%"))
+        assert item.font_family == "Arial"
+
+    def test_font_family_custom(self):
+        item = ContentItem(
+            type="text",
+            content="Hello",
+            position=("50%", "50%"),
+            font_family="Helvetica",
+        )
+        assert item.font_family == "Helvetica"
+
+    def test_font_family_none_uses_default(self):
+        item = ContentItem(
+            type="text",
+            content="Hello",
+            position=("50%", "50%"),
+            font_family=None,
+        )
+        assert item.font_family is None
+
+
 class TestContentItemHighlight:
     """Tests for ContentItem with type='highlight'."""
 


### PR DESCRIPTION
## Summary
- Exposes `font_family` in `ContentItem` so YAML configs can specify custom fonts for text content
- The field was already supported in `TextOverlay` and the text renderer but wasn't wired through from the YAML config layer
- Default is `"Arial"` (matching `TextOverlay` default)

Closes #3

## Changes
- `src/koubou/config.py` — Added `font_family` field to `ContentItem`
- `src/koubou/generator.py` — Map `font_family` when converting `ContentItem` → `TextOverlay`
- `docs/yaml-api.md` — Documented the new field in the Text Content Item schema
- `tests/test_config.py` — 3 new tests for default, custom, and None values
- `CHANGELOG.md` — Added entry under `[Unreleased]`

## Test plan
- [x] All 320 tests pass (`make test`)
- [x] New tests cover default value, custom value, and None case