### PR TITLE
feat: add App Store desktop output size presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ kou list-sizes
 - `iPhone6_1` - iPhone 16/15/14/13 Pro (1179×2556)
 - `iPadPro12_9` - iPad Pro 12.9" (2048×2732)
 - `iPadPro11` - iPad Pro 11", iPad Air 11" M2 (1668×2388)
+- `AppDesktop_2880` - Mac App Store desktop (2880×1800)
+- `AppDesktop_2560` - Mac App Store desktop (2560×1600)
+- `AppDesktop_1440` - Mac App Store desktop (1440×900)
+- `AppDesktop_1280` - Mac App Store desktop (1280×800)
 
 ### Custom Sizes
 

--- a/src/koubou/appstore_sizes.json
+++ b/src/koubou/appstore_sizes.json
@@ -38,5 +38,25 @@
     "width": 2064,
     "height": 2752,
     "description": "iPad Pro 13\" M4, iPad Air 13\" M2"
+  },
+  "AppDesktop_1280": {
+    "width": 1280,
+    "height": 800,
+    "description": "Mac App Store desktop (16:10, 1280×800)"
+  },
+  "AppDesktop_1440": {
+    "width": 1440,
+    "height": 900,
+    "description": "Mac App Store desktop (16:10, 1440×900)"
+  },
+  "AppDesktop_2560": {
+    "width": 2560,
+    "height": 1600,
+    "description": "Mac App Store desktop (16:10, 2560×1600)"
+  },
+  "AppDesktop_2880": {
+    "width": 2880,
+    "height": 1800,
+    "description": "Mac App Store desktop (16:10, 2880×1800)"
   }
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -128,6 +128,15 @@ class TestScreenshotConfig:
         # iPhone6_9 should resolve to (1320, 2868)
         assert config.output_size == (1320, 2868)
 
+    def test_named_appstore_desktop_size(self, sample_image):
+        """Test named desktop App Store size is resolved correctly."""
+        config = ScreenshotConfig(
+            name="Desktop Test",
+            source_image=sample_image,
+            output_size="AppDesktop_2880",
+        )
+        assert config.output_size == (2880, 1800)
+
     def test_invalid_named_size(self, sample_image):
         """Test invalid named size fails validation."""
         with pytest.raises(ValidationError, match="Unknown App Store size"):


### PR DESCRIPTION
## Summary
- add four named desktop output sizes for Mac App Store screenshots: `AppDesktop_1280`, `AppDesktop_1440`, `AppDesktop_2560`, and `AppDesktop_2880`
- keep preset dimensions in `appstore_sizes.json` so `output_size` works without custom per-project dimension tuples
- document the new desktop presets in README and add config validation coverage for `AppDesktop_2880`

## Test plan
- [x] `./.venv/bin/pytest tests/test_config.py`
- [x] `./.venv/bin/kou list-sizes --output json`