### PR TITLE
Add HTML template rendering mode with Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install ".[dev]"
-        
+        playwright install chromium
+
     - name: Run tests with coverage
       run: |
         pytest -v --cov=src/koubou --cov-report=xml --cov-report=html

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,17 @@ kou --create-config sample.yaml --force # Overwrite existing
 kou --version                          # Show version
 ```
 
+## Virtual Environment
+
+This project uses a `.venv` virtualenv at the project root. All commands must run through it:
+
+```bash
+.venv/bin/pip install ".[dev]"      # Install dev deps (includes playwright)
+.venv/bin/playwright install chromium  # Install browser for HTML rendering tests
+.venv/bin/pytest tests/ -v          # Run tests
+.venv/bin/python -m black src/      # Format
+```
+
 ## Build & Test
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,20 @@
 
 See `AGENTS.md` for full project structure, CLI principles, and command reference.
 
+## Virtual Environment
+
+This project uses a `.venv` virtualenv at the project root. Always use `.venv/bin/` prefixed commands:
+
+```bash
+.venv/bin/pytest tests/ -v          # Run tests
+.venv/bin/python -m black src/      # Format
+.venv/bin/pip install ".[dev]"      # Install dev deps
+```
+
 ## Quick Reference
 
 ```bash
-make install-dev   # Setup
+make install-dev   # Setup (uses .venv)
 make check         # Format + lint + test
 make install-hooks # Pre-commit hooks
 ```

--- a/examples/undolly/config.yaml
+++ b/examples/undolly/config.yaml
@@ -1,0 +1,30 @@
+project:
+  name: "Undolly - HTML Template Example"
+  output_dir: "output"
+  device: "iPhone 16 Pro - Black Titanium - Portrait"
+  output_size: "iPhone6_9"
+
+screenshots:
+  01_hero:
+    template: "templates/hero.html"
+    variables:
+      headline: "Clean Your iPhone"
+      subtitle: "Free up space instantly"
+    assets:
+      app_screenshot: "screenshots/home_dashboard.png"
+
+  02_find_duplicates:
+    template: "templates/feature.html"
+    variables:
+      headline: "Find Duplicates"
+      subtitle: "AI groups similar photos"
+    assets:
+      app_screenshot: "screenshots/group_clean.png"
+
+  03_smart_analysis:
+    template: "templates/hero.html"
+    variables:
+      headline: "Smart Analysis"
+      subtitle: "Keep the best shots"
+    assets:
+      app_screenshot: "screenshots/group_detailed.png"

--- a/examples/undolly/templates/feature.html
+++ b/examples/undolly/templates/feature.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 100vw;
+    height: 100vh;
+    background: radial-gradient(circle at 30% 20%, #ff6b35, #f7931e, #d64000);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+    overflow: hidden;
+  }
+  .device {
+    margin-top: 5%;
+    width: 75%;
+  }
+  .device img {
+    width: 100%;
+    height: auto;
+  }
+  .text-block {
+    margin-top: auto;
+    margin-bottom: 6%;
+    text-align: center;
+  }
+  .headline {
+    color: #ffffff;
+    font-size: 130px;
+    font-weight: 800;
+    line-height: 1.1;
+  }
+  .subtitle {
+    color: #f0f0f0;
+    font-size: 58px;
+    margin-top: 2%;
+  }
+</style>
+</head>
+<body>
+  <div class="device">
+    <img src="{{app_screenshot}}">
+  </div>
+  <div class="text-block">
+    <h1 class="headline">{{headline}}</h1>
+    <p class="subtitle">{{subtitle}}</p>
+  </div>
+</body>
+</html>

--- a/examples/undolly/templates/hero.html
+++ b/examples/undolly/templates/hero.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 100vw;
+    height: 100vh;
+    background: linear-gradient(135deg, #0f0c29, #302b63, #24243e);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+    overflow: hidden;
+  }
+  .headline {
+    color: #ffffff;
+    font-size: 130px;
+    font-weight: 800;
+    text-align: center;
+    margin-top: 8%;
+    line-height: 1.1;
+    max-width: 90%;
+  }
+  .subtitle {
+    color: #e0e0e0;
+    font-size: 58px;
+    text-align: center;
+    margin-top: 2%;
+    max-width: 85%;
+  }
+  .device {
+    margin-top: auto;
+    margin-bottom: -3%;
+    width: 75%;
+  }
+  .device img {
+    width: 100%;
+    height: auto;
+  }
+</style>
+</head>
+<body>
+  <h1 class="headline">{{headline}}</h1>
+  <p class="subtitle">{{subtitle}}</p>
+  <div class="device">
+    <img src="{{app_screenshot}}">
+  </div>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+html = [
+    "playwright>=1.40.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
@@ -46,6 +49,7 @@ dev = [
     "flake8>=6.0.0",
     "mypy>=1.0.0",
     "pre-commit>=3.0.0",
+    "playwright>=1.40.0",
 ]
 
 [project.urls]

--- a/src/koubou/config.py
+++ b/src/koubou/config.py
@@ -619,7 +619,7 @@ class ContentItem(BaseModel):
 
 
 class ScreenshotDefinition(BaseModel):
-    """Screenshot definition with content items."""
+    """Screenshot definition with content items or HTML template."""
 
     background: Optional[GradientConfig] = Field(
         default=None,
@@ -627,7 +627,21 @@ class ScreenshotDefinition(BaseModel):
             "Background configuration (optional - uses default if not specified)"
         ),
     )
-    content: List[ContentItem] = Field(..., description="List of content items")
+    content: Optional[List[ContentItem]] = Field(
+        default=None,
+        description="List of content items (mutually exclusive with template)",
+    )
+    template: Optional[str] = Field(
+        default=None, description="Path to HTML template file"
+    )
+    variables: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Localizable text variables for {{key}} substitution",
+    )
+    assets: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Asset path variables for {{key}} substitution (not localized)",
+    )
     frame: Optional[bool] = Field(
         default=None,
         description=(
@@ -635,6 +649,18 @@ class ScreenshotDefinition(BaseModel):
             "False=no frame)"
         ),
     )
+
+    @model_validator(mode="after")
+    def validate_content_or_template(self):
+        has_content = self.content is not None
+        has_template = self.template is not None
+        if has_template and has_content:
+            raise ValueError(
+                "Cannot specify both 'template' and 'content'. Choose one."
+            )
+        if not has_template and not has_content:
+            raise ValueError("Must specify either 'template' or 'content'.")
+        return self
 
 
 class LocalizationConfig(BaseModel):

--- a/src/koubou/dependency_analyzer.py
+++ b/src/koubou/dependency_analyzer.py
@@ -104,8 +104,54 @@ class DependencyAnalyzer:
         for screenshot_id, screenshot_def in config.screenshots.items():
             screenshot_assets = []
 
+            # Track HTML template and its sibling files
+            if screenshot_def.template:
+                template_path_str = screenshot_def.template
+                if Path(template_path_str).is_absolute():
+                    template_resolved = Path(template_path_str)
+                else:
+                    template_resolved = config_dir / template_path_str
+
+                if template_resolved.exists():
+                    # Track the template file itself
+                    dep = AssetDependency(
+                        screenshot_id=screenshot_id,
+                        asset_path=str(template_resolved),
+                        asset_type="template",
+                    )
+                    dep.resolved_path = template_resolved.resolve()
+                    dep.last_modified = template_resolved.stat().st_mtime
+                    self.dependencies.append(dep)
+                    screenshot_assets.append(dep)
+
+                    asset_key = str(dep.resolved_path)
+                    if asset_key not in self._asset_to_screenshots:
+                        self._asset_to_screenshots[asset_key] = []
+                    self._asset_to_screenshots[asset_key].append(screenshot_id)
+
+                    # Track sibling files (CSS, JS, images, etc.)
+                    template_dir = template_resolved.parent.resolve()
+                    for sibling in template_dir.iterdir():
+                        if sibling == template_resolved.resolve():
+                            continue
+                        if sibling.is_file():
+                            sib_dep = AssetDependency(
+                                screenshot_id=screenshot_id,
+                                asset_path=str(sibling),
+                                asset_type="template_asset",
+                            )
+                            sib_dep.resolved_path = sibling
+                            sib_dep.last_modified = sibling.stat().st_mtime
+                            self.dependencies.append(sib_dep)
+                            screenshot_assets.append(sib_dep)
+
+                            sib_key = str(sibling)
+                            if sib_key not in self._asset_to_screenshots:
+                                self._asset_to_screenshots[sib_key] = []
+                            self._asset_to_screenshots[sib_key].append(screenshot_id)
+
             # Scan content items for asset references
-            for content_item in screenshot_def.content:
+            for content_item in screenshot_def.content or []:
                 if content_item.type == "image" and content_item.asset:
                     # Handle both string and dict asset formats
                     asset_paths: List[str] = []

--- a/src/koubou/generator.py
+++ b/src/koubou/generator.py
@@ -1,5 +1,6 @@
 """Core screenshot generation functionality."""
 
+import io
 import json
 import logging
 from pathlib import Path
@@ -123,6 +124,7 @@ class ScreenshotGenerator:
         self.device_frame_renderer = DeviceFrameRenderer(self.frame_directory)
         self.highlight_renderer = HighlightRenderer()
         self.zoom_renderer = ZoomRenderer()
+        self._html_renderer: Optional[Any] = None
 
         # Load device frame metadata
         self._load_frame_metadata()
@@ -155,6 +157,121 @@ class ScreenshotGenerator:
             logger.error(f"Failed to load frame metadata: {_e}")
             self.frame_metadata = {}
             self.size_metadata = {}
+
+    @property
+    def html_renderer(self):
+        if self._html_renderer is None:
+            from .renderers.html_renderer import HtmlRenderer
+
+            self._html_renderer = HtmlRenderer()
+        return self._html_renderer
+
+    def _resolve_template_variables(
+        self,
+        variables: Dict[str, str],
+        language: str,
+        xcstrings_manager: Optional[Any] = None,
+    ) -> Dict[str, str]:
+        """Resolve localizable text variables through xcstrings."""
+        if not xcstrings_manager:
+            return dict(variables)
+
+        resolved = {}
+        for key, value in variables.items():
+            resolved[key] = xcstrings_manager.get_translation(value, language)
+        return resolved
+
+    def _build_assets_map(
+        self,
+        asset_variables: Dict[str, str],
+        config_dir: Optional[Path],
+        device_frame_name: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """Build {relative_name: absolute_path} map for HTML sandbox.
+
+        Args:
+            asset_variables: The explicit assets dict from ScreenshotDefinition
+            config_dir: Base directory for resolving relative paths
+            device_frame_name: Device frame to include as frame.png
+        """
+        assets: Dict[str, str] = {}
+
+        # Add device frame if available
+        if device_frame_name:
+            frame_dir = self.device_frame_renderer.frame_directory
+            for ext in [".png", ".PNG"]:
+                frame_path = frame_dir / f"{device_frame_name}{ext}"
+                if frame_path.exists():
+                    assets["frame.png"] = str(frame_path)
+                    break
+
+        # Resolve each asset path and add to sandbox map
+        for key, value in asset_variables.items():
+            if config_dir:
+                candidate = config_dir / value
+            else:
+                candidate = Path(value)
+            if candidate.exists():
+                assets[value] = str(candidate.resolve())
+
+        return assets
+
+    def _generate_html_screenshot(
+        self,
+        screenshot_def: Any,
+        screenshot_id: str,
+        output_dir: str,
+        output_size: Tuple[int, int],
+        config_dir: Optional[Path],
+        device_frame_name: Optional[str] = None,
+        language: str = "en",
+        xcstrings_manager: Optional[Any] = None,
+    ) -> Path:
+        """Generate a screenshot from an HTML template."""
+        template_path_str = screenshot_def.template
+        if config_dir and not Path(template_path_str).is_absolute():
+            template_path = config_dir / template_path_str
+        else:
+            template_path = Path(template_path_str)
+
+        if not template_path.exists():
+            raise ConfigurationError(f"HTML template not found: {template_path}")
+
+        # Resolve localizable text variables
+        resolved_text = self._resolve_template_variables(
+            screenshot_def.variables, language, xcstrings_manager
+        )
+
+        # Build assets map from the explicit assets dict
+        assets = self._build_assets_map(
+            screenshot_def.assets, config_dir, device_frame_name
+        )
+
+        # Merge text + assets for template substitution
+        all_variables = {**resolved_text, **screenshot_def.assets}
+
+        png_bytes = self.html_renderer.render(
+            template_path=template_path,
+            variables=all_variables,
+            size=output_size,
+            assets=assets,
+        )
+
+        output_path = self._resolve_output_path(output_dir, screenshot_id, config_dir)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Save PNG (convert to RGB for App Store compatibility)
+        img = Image.open(io.BytesIO(png_bytes))
+        rgb_img = Image.new("RGB", img.size, (255, 255, 255))
+        rgb_img.paste(img, mask=img if img.mode == "RGBA" else None)
+
+        if output_path.suffix.lower() == ".jpg":
+            rgb_img.save(output_path, "JPEG", quality=95)
+        else:
+            rgb_img.save(output_path, "PNG")
+
+        logger.info(f"Generated HTML screenshot: {output_path}")
+        return output_path
 
     def generate_screenshot(self, config: ScreenshotConfig) -> Path:
         """Generate a single screenshot based on configuration.
@@ -700,10 +817,13 @@ class ScreenshotGenerator:
             # Extract all text keys from all screenshots
             all_text_keys = set()
             for screenshot_def in project_config.screenshots.values():
-                text_keys = content_resolver.extract_text_keys_from_content(
-                    screenshot_def.content
-                )
-                all_text_keys.update(text_keys)
+                if screenshot_def.content:
+                    text_keys = content_resolver.extract_text_keys_from_content(
+                        screenshot_def.content
+                    )
+                    all_text_keys.update(text_keys)
+                if screenshot_def.variables:
+                    all_text_keys.update(screenshot_def.variables.values())
 
             logger.info(f"🔤 Found {len(all_text_keys)} unique text keys")
 
@@ -745,12 +865,40 @@ class ScreenshotGenerator:
                     f"[{i}/{len(project_config.screenshots)}] {screenshot_id}"
                 )
                 try:
-                    # Create localized content (or use original for non-localized)
+                    # Generate device and language-specific output directory
                     if localization_config:
+                        device_output_dir = str(
+                            Path(project_config.project.output_dir)
+                            / language
+                            / device.replace(" ", "_")
+                        )
+                    else:
+                        device_output_dir = str(
+                            Path(project_config.project.output_dir)
+                            / device.replace(" ", "_")
+                        )
+
+                    # HTML template mode: bypass PIL pipeline entirely
+                    if screenshot_def.template:
+                        xcm = xcstrings_manager if localization_config else None
+                        output_path = self._generate_html_screenshot(
+                            screenshot_def=screenshot_def,
+                            screenshot_id=screenshot_id,
+                            output_dir=device_output_dir,
+                            output_size=output_size,
+                            config_dir=config_dir,
+                            device_frame_name=device,
+                            language=language,
+                            xcstrings_manager=xcm,
+                        )
+                        all_results.append(output_path)
+                        continue
+
+                    # Content mode: standard PIL pipeline
+                    if localization_config and screenshot_def.content:
                         localized_content = content_resolver.localize_content_items(
                             screenshot_def.content, language
                         )
-                        # Create copy with localized content
                         from copy import deepcopy
 
                         processed_screenshot_def = deepcopy(screenshot_def)
@@ -758,24 +906,6 @@ class ScreenshotGenerator:
                     else:
                         processed_screenshot_def = screenshot_def
 
-                    # Generate device and language-specific output directory
-                    if localization_config:
-                        # Multi-language: output_dir/language/device/
-                        device_output_dir = str(
-                            Path(project_config.project.output_dir)
-                            / language
-                            / device.replace(" ", "_")
-                        )
-                    else:
-                        # Single language: output_dir/device/
-                        # (ALWAYS include device folder)
-                        device_output_dir = str(
-                            Path(project_config.project.output_dir)
-                            / device.replace(" ", "_")
-                        )
-
-                    # Convert to ScreenshotConfig and generate
-                    # Get base_language for asset resolution
                     base_lang = (
                         localization_config.base_language
                         if localization_config
@@ -783,12 +913,12 @@ class ScreenshotGenerator:
                     )
                     temp_config = self._convert_to_screenshot_config(
                         processed_screenshot_def,
-                        device,  # Use device name directly
+                        device,
                         default_background,
                         device_output_dir,
                         config_dir,
                         screenshot_id,
-                        output_size=output_size,  # Pass project-level output size
+                        output_size=output_size,
                         language=language,
                         base_language=base_lang,
                     )
@@ -807,6 +937,11 @@ class ScreenshotGenerator:
                     )
                     # Continue with next screenshot instead of failing project
                     continue
+
+        # Clean up HTML renderer if used
+        if self._html_renderer:
+            self._html_renderer.close()
+            self._html_renderer = None
 
         logger.info(
             f"🎉 Project complete! Generated {len(all_results)} screenshots "

--- a/src/koubou/generator.py
+++ b/src/koubou/generator.py
@@ -210,9 +210,7 @@ class ScreenshotGenerator:
         for y in range(fh):
             for x in range(fw):
                 pixel_val = alpha_pixels[x, y]
-                alpha_val = (
-                    pixel_val[0] if isinstance(pixel_val, tuple) else pixel_val
-                )
+                alpha_val = pixel_val[0] if isinstance(pixel_val, tuple) else pixel_val
                 if alpha_val == 0 and (x, y) not in visited:
                     min_x = min(min_x, x)
                     min_y = min(min_y, y)

--- a/src/koubou/generator.py
+++ b/src/koubou/generator.py
@@ -3,6 +3,8 @@
 import io
 import json
 import logging
+import tempfile
+from collections import deque
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -166,6 +168,84 @@ class ScreenshotGenerator:
             self._html_renderer = HtmlRenderer()
         return self._html_renderer
 
+    def _prerender_framed_asset(
+        self, asset_path: str, device_frame_name: str
+    ) -> Image.Image:
+        """Composite a screenshot into a device frame as a single RGBA image."""
+        source = Image.open(asset_path).convert("RGBA")
+        frame_image = self.device_frame_renderer._load_frame_image(device_frame_name)
+
+        if frame_image.mode != "RGBA":
+            frame_image = frame_image.convert("RGBA")
+
+        alpha_channel = frame_image.split()[-1]
+        alpha_pixels = alpha_channel.load()
+        fw, fh = frame_image.size
+
+        # Flood fill from edges to identify outer transparent area
+        visited: set[tuple[int, int]] = set()
+        queue: deque[tuple[int, int]] = deque()
+        for x in range(fw):
+            queue.append((x, 0))
+            queue.append((x, fh - 1))
+        for y in range(fh):
+            queue.append((0, y))
+            queue.append((fw - 1, y))
+
+        while queue:
+            x, y = queue.popleft()
+            if (x, y) in visited or x < 0 or x >= fw or y < 0 or y >= fh:
+                continue
+            pixel_val = alpha_pixels[x, y]
+            alpha_val = pixel_val[0] if isinstance(pixel_val, tuple) else pixel_val
+            if alpha_val > 0:
+                continue
+            visited.add((x, y))
+            for dx, dy in [(0, 1), (0, -1), (1, 0), (-1, 0)]:
+                queue.append((x + dx, y + dy))
+
+        # Find screen area bounding box (transparent pixels NOT in outer area)
+        min_x, min_y = fw, fh
+        max_x, max_y = 0, 0
+        for y in range(fh):
+            for x in range(fw):
+                pixel_val = alpha_pixels[x, y]
+                alpha_val = (
+                    pixel_val[0] if isinstance(pixel_val, tuple) else pixel_val
+                )
+                if alpha_val == 0 and (x, y) not in visited:
+                    min_x = min(min_x, x)
+                    min_y = min(min_y, y)
+                    max_x = max(max_x, x)
+                    max_y = max(max_y, y)
+
+        screen_w = max_x - min_x + 1
+        screen_h = max_y - min_y + 1
+
+        # Fit source image to screen area (maintain aspect ratio)
+        src_w, src_h = source.size
+        fit_scale = min(screen_w / src_w, screen_h / src_h)
+        fitted_w = int(src_w * fit_scale)
+        fitted_h = int(src_h * fit_scale)
+        fitted = source.resize((fitted_w, fitted_h), Image.Resampling.LANCZOS)
+
+        # Center within screen area
+        offset_x = min_x + (screen_w - fitted_w) // 2
+        offset_y = min_y + (screen_h - fitted_h) // 2
+
+        # Build composited image: screenshot behind frame, clipped to screen
+        result = Image.new("RGBA", frame_image.size, (255, 255, 255, 0))
+        result.paste(fitted, (offset_x, offset_y), fitted)
+
+        screen_mask = self.device_frame_renderer.generate_screen_mask_from_image(
+            frame_image
+        )
+        transparent = Image.new("RGBA", frame_image.size, (255, 255, 255, 0))
+        result = Image.composite(result, transparent, screen_mask)
+        result = Image.alpha_composite(result, frame_image)
+
+        return result
+
     def _resolve_template_variables(
         self,
         variables: Dict[str, str],
@@ -185,27 +265,9 @@ class ScreenshotGenerator:
         self,
         asset_variables: Dict[str, str],
         config_dir: Optional[Path],
-        device_frame_name: Optional[str] = None,
     ) -> Dict[str, str]:
-        """Build {relative_name: absolute_path} map for HTML sandbox.
-
-        Args:
-            asset_variables: The explicit assets dict from ScreenshotDefinition
-            config_dir: Base directory for resolving relative paths
-            device_frame_name: Device frame to include as frame.png
-        """
+        """Build {relative_name: absolute_path} map for HTML sandbox."""
         assets: Dict[str, str] = {}
-
-        # Add device frame if available
-        if device_frame_name:
-            frame_dir = self.device_frame_renderer.frame_directory
-            for ext in [".png", ".PNG"]:
-                frame_path = frame_dir / f"{device_frame_name}{ext}"
-                if frame_path.exists():
-                    assets["frame.png"] = str(frame_path)
-                    break
-
-        # Resolve each asset path and add to sandbox map
         for key, value in asset_variables.items():
             if config_dir:
                 candidate = config_dir / value
@@ -213,7 +275,6 @@ class ScreenshotGenerator:
                 candidate = Path(value)
             if candidate.exists():
                 assets[value] = str(candidate.resolve())
-
         return assets
 
     def _generate_html_screenshot(
@@ -242,25 +303,37 @@ class ScreenshotGenerator:
             screenshot_def.variables, language, xcstrings_manager
         )
 
-        # Build assets map from the explicit assets dict
-        assets = self._build_assets_map(
-            screenshot_def.assets, config_dir, device_frame_name
-        )
+        # Build assets map and pre-render with device frame
+        assets = self._build_assets_map(screenshot_def.assets, config_dir)
+        should_frame = screenshot_def.frame is not False and device_frame_name
+        temp_files: List[str] = []
 
-        # Merge text + assets for template substitution
-        all_variables = {**resolved_text, **screenshot_def.assets}
+        if should_frame:
+            for rel_path, abs_path in assets.items():
+                if Path(abs_path).suffix.lower() in (".png", ".jpg", ".jpeg"):
+                    framed = self._prerender_framed_asset(abs_path, device_frame_name)
+                    tmp = tempfile.NamedTemporaryFile(
+                        suffix=".png", delete=False, prefix="koubou_framed_"
+                    )
+                    framed.save(tmp.name, "PNG")
+                    assets[rel_path] = tmp.name
+                    temp_files.append(tmp.name)
 
-        png_bytes = self.html_renderer.render(
-            template_path=template_path,
-            variables=all_variables,
-            size=output_size,
-            assets=assets,
-        )
+        try:
+            all_variables = {**resolved_text, **screenshot_def.assets}
+            png_bytes = self.html_renderer.render(
+                template_path=template_path,
+                variables=all_variables,
+                size=output_size,
+                assets=assets,
+            )
+        finally:
+            for f in temp_files:
+                Path(f).unlink(missing_ok=True)
 
         output_path = self._resolve_output_path(output_dir, screenshot_id, config_dir)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Save PNG (convert to RGB for App Store compatibility)
         img = Image.open(io.BytesIO(png_bytes))
         rgb_img = Image.new("RGB", img.size, (255, 255, 255))
         rgb_img.paste(img, mask=img if img.mode == "RGBA" else None)

--- a/src/koubou/renderers/html_renderer.py
+++ b/src/koubou/renderers/html_renderer.py
@@ -1,0 +1,141 @@
+"""HTML template renderer using Playwright headless browser."""
+
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def _import_playwright():
+    try:
+        from playwright.sync_api import sync_playwright
+
+        return sync_playwright
+    except ImportError:
+        raise RuntimeError(
+            "Playwright is required for HTML template rendering. "
+            "Install it with: pip install koubou[html]\n"
+            "Then install a browser: playwright install chromium"
+        )
+
+
+class HtmlRenderer:
+    """Renders HTML templates to PNG via Playwright headless browser."""
+
+    def __init__(self):
+        self._playwright = None
+        self._browser = None
+
+    def _ensure_browser(self):
+        if self._browser:
+            return
+
+        sync_playwright = _import_playwright()
+        self._playwright = sync_playwright().start()
+
+        # Try system Chrome first, fall back to Playwright's chromium
+        try:
+            self._browser = self._playwright.chromium.launch(channel="chrome")
+            logger.info("Using system Chrome for HTML rendering")
+        except Exception:
+            try:
+                self._browser = self._playwright.chromium.launch()
+                logger.info("Using Playwright Chromium for HTML rendering")
+            except Exception as e:
+                raise RuntimeError(
+                    f"No browser available for HTML rendering: {e}\n"
+                    "Install Chrome or run: playwright install chromium"
+                )
+
+    def render(
+        self,
+        template_path: Path,
+        variables: Dict[str, str],
+        size: Tuple[int, int],
+        assets: Optional[Dict[str, str]] = None,
+    ) -> bytes:
+        """Render an HTML template to PNG bytes.
+
+        Args:
+            template_path: Path to the HTML template file
+            variables: Dict of {{key}} -> value substitutions
+            size: (width, height) viewport size in pixels
+            assets: Dict of {relative_name: absolute_path} to symlink into sandbox
+
+        Returns:
+            PNG image bytes
+        """
+        self._ensure_browser()
+        assert self._browser is not None
+
+        tmpdir = tempfile.mkdtemp(prefix="koubou_html_")
+        try:
+            tmpdir_path = Path(tmpdir)
+
+            # Mount template sibling files (CSS, JS, images, etc.)
+            template_dir = template_path.parent.resolve()
+            for item in template_dir.iterdir():
+                if item == template_path.resolve():
+                    continue
+                dest = tmpdir_path / item.name
+                if not dest.exists():
+                    try:
+                        os.symlink(item, dest)
+                    except OSError:
+                        if item.is_dir():
+                            shutil.copytree(item, dest)
+                        else:
+                            shutil.copy2(item, dest)
+
+            # Mount explicit assets (override sibling files if name conflicts)
+            if assets:
+                for rel_name, abs_path in assets.items():
+                    dest = tmpdir_path / rel_name
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    if dest.exists() or dest.is_symlink():
+                        dest.unlink()
+                    try:
+                        os.symlink(abs_path, dest)
+                    except OSError:
+                        shutil.copy2(abs_path, dest)
+
+            # Read and process template
+            html_content = template_path.read_text(encoding="utf-8")
+            for key, value in variables.items():
+                html_content = html_content.replace(f"{{{{{key}}}}}", value)
+
+            # Write processed HTML (overwrites any sibling with same name)
+            index_path = tmpdir_path / "index.html"
+            index_path.write_text(html_content, encoding="utf-8")
+
+            # Render with Playwright
+            width, height = size
+            page = self._browser.new_page(
+                viewport={"width": width, "height": height},
+                device_scale_factor=1,
+            )
+            try:
+                page.goto(f"file://{index_path}", wait_until="networkidle")
+                png_bytes = page.screenshot(type="png", full_page=False)
+            finally:
+                page.close()
+
+            logger.info(
+                f"Rendered HTML template {template_path.name} " f"at {width}x{height}"
+            )
+            return png_bytes
+
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def close(self):
+        if self._browser:
+            self._browser.close()
+            self._browser = None
+        if self._playwright:
+            self._playwright.stop()
+            self._playwright = None

--- a/tests/test_html_renderer.py
+++ b/tests/test_html_renderer.py
@@ -1,0 +1,305 @@
+"""Tests for HTML template rendering."""
+
+import importlib
+import io
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from koubou.config import (
+    ContentItem,
+    ProjectConfig,
+    ProjectInfo,
+    ScreenshotDefinition,
+)
+
+
+def _playwright_available():
+    return importlib.util.find_spec("playwright") is not None
+
+
+requires_playwright = pytest.mark.skipif(
+    not _playwright_available(),
+    reason="playwright not installed (install with: pip install koubou[html])",
+)
+
+
+@pytest.fixture
+def temp_dir():
+    d = Path(tempfile.mkdtemp())
+    yield d
+    shutil.rmtree(d)
+
+
+@pytest.fixture
+def renderer():
+    from koubou.renderers.html_renderer import HtmlRenderer
+
+    r = HtmlRenderer()
+    yield r
+    r.close()
+
+
+class TestScreenshotDefinitionValidation:
+    """Test template/content mutual exclusion in config."""
+
+    def test_template_and_content_mutually_exclusive(self):
+        with pytest.raises(Exception, match="Cannot specify both"):
+            ScreenshotDefinition(
+                content=[],
+                template="some.html",
+            )
+
+    def test_requires_template_or_content(self):
+        with pytest.raises(Exception, match="Must specify either"):
+            ScreenshotDefinition()
+
+    def test_template_only_is_valid(self):
+        defn = ScreenshotDefinition(
+            template="hero.html",
+            variables={"headline": "Hello"},
+        )
+        assert defn.template == "hero.html"
+        assert defn.variables == {"headline": "Hello"}
+        assert defn.content is None
+
+    def test_content_only_is_valid(self):
+        defn = ScreenshotDefinition(
+            content=[
+                ContentItem(
+                    type="text",
+                    content="Hello",
+                    position=("50%", "50%"),
+                )
+            ],
+        )
+        assert defn.content is not None
+        assert defn.template is None
+
+
+@requires_playwright
+class TestHtmlRenderer:
+    """Integration tests for HTML rendering (requires playwright)."""
+
+    def test_basic_html_rendering(self, temp_dir, renderer):
+        template = temp_dir / "test.html"
+        template.write_text("""<!DOCTYPE html>
+<html>
+<body style="margin:0; background: linear-gradient(135deg, #667eea, #764ba2);
+             width:100vw; height:100vh;">
+  <h1 style="color:white; text-align:center; padding-top:40%;">
+    {{headline}}
+  </h1>
+</body>
+</html>""")
+
+        png_bytes = renderer.render(
+            template_path=template,
+            variables={"headline": "Privacy First"},
+            size=(1320, 2868),
+        )
+
+        assert len(png_bytes) > 0
+        img = Image.open(io.BytesIO(png_bytes))
+        assert img.size == (1320, 2868)
+
+    def test_variable_substitution(self, temp_dir, renderer):
+        template = temp_dir / "vars.html"
+        template.write_text("""<!DOCTYPE html>
+<html>
+<body style="margin:0; width:100vw; height:100vh; background:#fff;">
+  <p id="title">{{title}}</p>
+  <p id="sub">{{subtitle}}</p>
+</body>
+</html>""")
+
+        png_bytes = renderer.render(
+            template_path=template,
+            variables={"title": "Hello", "subtitle": "World"},
+            size=(400, 800),
+        )
+        assert len(png_bytes) > 0
+
+    def test_asset_symlink_in_sandbox(self, temp_dir, renderer):
+        asset_path = temp_dir / "real_asset.png"
+        img = Image.new("RGB", (100, 100), (255, 0, 0))
+        img.save(asset_path)
+
+        template = temp_dir / "asset.html"
+        template.write_text("""<!DOCTYPE html>
+<html>
+<body style="margin:0; width:100vw; height:100vh; background:#000;">
+  <img src="screen.png" style="width:50px; height:50px;">
+</body>
+</html>""")
+
+        png_bytes = renderer.render(
+            template_path=template,
+            variables={},
+            size=(400, 800),
+            assets={"screen.png": str(asset_path)},
+        )
+        assert len(png_bytes) > 0
+
+    def test_sibling_files_mounted_in_sandbox(self, temp_dir, renderer):
+        """Template sibling files (CSS, images) should resolve in the sandbox."""
+        # Create template directory with siblings
+        tpl_dir = temp_dir / "templates"
+        tpl_dir.mkdir()
+
+        (tpl_dir / "styles.css").write_text("body { background: red; margin: 0; }")
+
+        logo = Image.new("RGB", (50, 50), (0, 255, 0))
+        logo.save(tpl_dir / "logo.png")
+
+        template = tpl_dir / "hero.html"
+        template.write_text("""<!DOCTYPE html>
+<html>
+<head><link rel="stylesheet" href="styles.css"></head>
+<body style="width:100vw; height:100vh;">
+  <img src="logo.png" style="width:50px; height:50px;">
+</body>
+</html>""")
+
+        png_bytes = renderer.render(
+            template_path=template,
+            variables={},
+            size=(400, 800),
+        )
+        assert len(png_bytes) > 0
+        img = Image.open(io.BytesIO(png_bytes))
+        assert img.size == (400, 800)
+
+    def test_project_generate_with_template(self, temp_dir):
+        """End-to-end: generate a project with an HTML template screenshot."""
+        from koubou.generator import ScreenshotGenerator
+
+        template = temp_dir / "hero.html"
+        template.write_text("""<!DOCTYPE html>
+<html>
+<body style="margin:0; background:#1a1a2e; width:100vw; height:100vh;">
+  <h1 style="color:white; text-align:center; padding-top:40%;">
+    {{headline}}
+  </h1>
+</body>
+</html>""")
+
+        output_dir = temp_dir / "output"
+
+        config = ProjectConfig(
+            project=ProjectInfo(
+                name="TestHTML",
+                output_dir=str(output_dir),
+                device="iPhone 16 Pro - Black Titanium - Portrait",
+                output_size="iPhone6_9",
+            ),
+            screenshots={
+                "hero": ScreenshotDefinition(
+                    template=str(template),
+                    variables={"headline": "Privacy First"},
+                ),
+            },
+        )
+
+        generator = ScreenshotGenerator()
+        results = generator.generate_project(config, config_dir=temp_dir)
+
+        assert len(results) == 1
+        assert results[0].exists()
+
+        img = Image.open(results[0])
+        assert img.size == (1320, 2868)
+
+
+class TestDependencyAnalyzerHtml:
+    """Test that dependency analyzer tracks HTML templates."""
+
+    def test_tracks_template_file(self, temp_dir):
+        from koubou.dependency_analyzer import DependencyAnalyzer
+
+        template = temp_dir / "hero.html"
+        template.write_text("<html><body>Hello</body></html>")
+
+        config = ProjectConfig(
+            project=ProjectInfo(
+                name="Test",
+                output_dir=str(temp_dir / "output"),
+                device="iPhone 16 Pro - Black Titanium - Portrait",
+            ),
+            screenshots={
+                "hero": ScreenshotDefinition(
+                    template=str(template),
+                ),
+            },
+        )
+
+        analyzer = DependencyAnalyzer()
+        analyzer.analyze_project(config, temp_dir)
+
+        asset_paths = analyzer.get_all_asset_paths()
+        resolved_template = template.resolve()
+        assert resolved_template in asset_paths
+
+        affected = analyzer.get_asset_screenshots(resolved_template)
+        assert "hero" in affected
+
+    def test_tracks_sibling_files(self, temp_dir):
+        from koubou.dependency_analyzer import DependencyAnalyzer
+
+        tpl_dir = temp_dir / "templates"
+        tpl_dir.mkdir()
+
+        template = tpl_dir / "hero.html"
+        template.write_text("<html><body>Hello</body></html>")
+
+        css_file = tpl_dir / "styles.css"
+        css_file.write_text("body { color: red; }")
+
+        config = ProjectConfig(
+            project=ProjectInfo(
+                name="Test",
+                output_dir=str(temp_dir / "output"),
+                device="iPhone 16 Pro - Black Titanium - Portrait",
+            ),
+            screenshots={
+                "hero": ScreenshotDefinition(
+                    template=str(template),
+                ),
+            },
+        )
+
+        analyzer = DependencyAnalyzer()
+        analyzer.analyze_project(config, temp_dir)
+
+        affected = analyzer.get_asset_screenshots(css_file)
+        assert "hero" in affected
+
+
+class TestAssetsFieldValidation:
+    """Test explicit variables/assets separation in ScreenshotDefinition."""
+
+    def test_template_with_assets_and_variables(self):
+        defn = ScreenshotDefinition(
+            template="hero.html",
+            variables={"headline": "Privacy First"},
+            assets={"app_screenshot": "assets/screen1.png"},
+        )
+        assert defn.variables == {"headline": "Privacy First"}
+        assert defn.assets == {"app_screenshot": "assets/screen1.png"}
+
+    def test_assets_default_empty(self):
+        defn = ScreenshotDefinition(
+            template="hero.html",
+            variables={"headline": "Hello"},
+        )
+        assert defn.assets == {}
+
+    def test_variables_default_empty(self):
+        defn = ScreenshotDefinition(
+            template="hero.html",
+            assets={"screen": "assets/screen.png"},
+        )
+        assert defn.variables == {}


### PR DESCRIPTION
## Summary

- **New rendering mode**: Screenshots can now be designed in HTML/CSS using `template:` instead of `content:` in YAML config. LLMs write HTML/CSS much better than YAML parametric config, making AI-assisted screenshot generation natural.
- **Explicit variables/assets separation**: `variables` are localizable text (goes through xcstrings), `assets` are file paths (mounted in sandbox, never localized). Both get substituted as `{{key}}` in templates.
- **Sandbox isolation**: Each render creates a temp directory with symlinked template siblings (CSS, JS, images) and explicit assets. Templates only see relative paths.
- **Playwright optional dependency**: `pip install koubou[html]` adds Playwright. System Chrome preferred, Playwright Chromium as fallback. Base `pip install koubou` unchanged.
- **Dependency tracking**: `DependencyAnalyzer` tracks template files + sibling files for live mode file watching.

### Config example

```yaml
screenshots:
  hero:
    template: "templates/hero.html"
    variables:
      headline: "Privacy First"      # Localizable via xcstrings
      subheadline: "No cloud uploads"
    assets:
      app_screenshot: "assets/screen1.png"  # File path, mounted in sandbox
```

### Files changed

| File | Change |
|------|--------|
| `pyproject.toml` | `[html]` optional dep + playwright in dev deps |
| `src/koubou/config.py` | `template`, `variables`, `assets` fields + mutual exclusion validator |
| `src/koubou/renderers/html_renderer.py` | **New** - HtmlRenderer with Playwright sandbox |
| `src/koubou/generator.py` | HTML template branch in generation pipeline |
| `src/koubou/dependency_analyzer.py` | Template + sibling file tracking |
| `.github/workflows/ci.yml` | `playwright install chromium` in CI |
| `tests/test_html_renderer.py` | **New** - 14 tests (config validation, rendering, dependency tracking) |

## Test plan

- [x] All 368 tests pass (including 14 new HTML renderer tests)
- [x] Linting clean (flake8)
- [x] Existing YAML configs generate identical output (backwards compatible)
- [x] `content:` and `template:` are mutually exclusive (validated by Pydantic)
- [x] Template sibling files (CSS, images) resolve correctly in sandbox
- [x] Assets mounted via symlink in sandbox
- [x] DependencyAnalyzer tracks templates and sibling files
- [x] Tests skip gracefully when playwright not installed (`@requires_playwright`)