### PR TITLE
Add koubou skill for App Store screenshot generation

### DIFF
--- a/skills/koubou/SKILL.md
+++ b/skills/koubou/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: koubou
+description: Generate App Store screenshots using HTML/CSS templates with real device frames. Creates professional, localized screenshots for iPhone, iPad, Mac, and Watch. Use when user wants to create, design, or update App Store screenshots.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash(pip *)
+  - Bash(pip3 *)
+  - Bash(kou *)
+  - Bash(playwright *)
+  - Bash(python *)
+  - Bash(python3 *)
+  - Bash(open *)
+  - Bash(mkdir *)
+  - Bash(ls *)
+  - Bash(cp *)
+user-invocable: true
+---
+
+# Koubou: App Store Screenshot Generator
+
+Generate professional App Store screenshots using HTML/CSS templates with 100+ real device frames, xcstrings localization, and pixel-perfect Apple dimensions.
+
+> Screenshots are advertisements, not documentation. Each slide sells one feeling, outcome, or pain-point solution.
+
+**User instructions always take priority over defaults in this skill.**
+
+Reference files (read as needed, not upfront):
+- `setup.md` — Installation of koubou + Playwright
+- `design-guide.md` — Design principles, copywriting rules, CSS rules, HTML template examples
+- `yaml-reference.md` — YAML config format, localization, assets, devices, sizes
+- `capabilities-reference.md` — Full koubou capabilities (content mode, highlights, zoom, gradients)
+
+## Phase 1: Setup (silent, automatic)
+
+Check if koubou is installed. If not, install it. Do not ask the user — just do it.
+
+```bash
+python3 -c "import koubou" 2>/dev/null || pip3 install "koubou[html]"
+playwright install chromium 2>/dev/null || true
+```
+
+Only inform the user if installation fails. Read `setup.md` for troubleshooting.
+
+## Phase 2: Gather Information
+
+Collect what you need through natural conversation. Do NOT dump all questions at once.
+
+### Required (ask in order, naturally)
+
+1. **App**: Name, what it does (1 sentence), main value proposition
+2. **Screenshots**: Where are the app captures? Search automatically first:
+   - Glob for: `.maestro/`, `screenshots/`, `AppStore/`, `fastlane/screenshots/`, `marketing/`
+   - If found, show what you found and confirm
+   - If not found, ask how the user generates them
+3. **Visual style**: Brand colors (accent, background), dark/light/colorful preference
+   - If `Assets.xcassets`, `marketing/plan.md`, or prior marketing exists, derive colors from there without asking
+4. **Features to highlight**: Prioritized list of features/benefits (recommend 3-5). Each slide = 1 feature
+5. **Slide count**: How many screenshots (recommend 3-5 to start, Apple allows up to 10)
+
+### Optional (ask only if relevant)
+
+6. **Device**: Default is `iPhone 16 Pro - Black Titanium - Portrait`. Only ask if iPad/Mac/other makes sense
+7. **Localization**: Only if the project already has xcstrings or multiple language support
+8. **Extra assets**: App icon, floating UI elements, badges
+
+### Derived (do NOT ask — figure out automatically)
+
+- Background gradients (from brand colors)
+- Layout distribution (hero → feature-top → feature-bottom → alternating)
+- Headline copy (from features and value proposition)
+- Secondary palette (variations of brand colors)
+
+**Principle**: If context is available (CLAUDE.md, existing configs, marketing/plan.md, Assets.xcassets), use it without re-asking.
+
+## Phase 3: Generate
+
+Read `design-guide.md` before generating templates. Read `yaml-reference.md` before writing config.
+
+1. Create working directory (e.g., `AppStore/` or wherever makes sense for the project)
+2. Create `templates/` with HTML templates — **minimum 3 distinct layouts** (read `design-guide.md` for templates)
+3. Create `config.yaml` with koubou config (read `yaml-reference.md` for format)
+4. Run: `kou generate config.yaml --verbose`
+5. Open output folder: `open <output_dir>`
+6. Ask if the user wants adjustments — iterate on specific slides without regenerating everything
+
+### Iteration Rules
+
+- When user asks to change a specific slide, only modify that template + config entry
+- When user asks for a global style change (colors, fonts), update all templates
+- Re-run `kou generate config.yaml --verbose` after changes
+- Use `kou live config.yaml` if user wants real-time preview while editing
+
+## Key Technical Details
+
+### How assets work in HTML templates
+
+In template HTML, reference assets with `{{asset_name}}`. In the YAML config, map `asset_name` to a file path under `assets:`.
+
+Koubou automatically pre-renders each image asset with the configured device frame before passing it to the HTML template. The template receives a composited image (screenshot inside device frame) — it just places it with `<img src="{{asset_name}}">`.
+
+To disable frame for a specific screenshot: set `frame: false` in its YAML definition.
+
+### Template variable substitution
+
+- `variables:` in YAML → `{{key}}` in HTML → localizable text (extracted to xcstrings)
+- `assets:` in YAML → `{{key}}` in HTML → image file paths (pre-rendered with device frame)
+
+### Output structure
+
+```
+{output_dir}/{language}/{device_name}/{screenshot_id}.png
+```
+
+Non-localized projects skip the language directory.
+
+### Device frame names
+
+Use exact names from `kou list-frames`. Common ones:
+- `iPhone 16 Pro - Black Titanium - Portrait`
+- `iPhone 16 Pro Max - Black Titanium - Portrait`
+- `iPad Pro 13 - M4 - Space Gray - Portrait`
+
+Search with: `kou list-frames "iPhone 16"`
+
+### Output sizes (App Store dimensions)
+
+| Name | Dimensions | Devices |
+|------|-----------|---------|
+| `iPhone6_9` | 1320x2868 | iPhone 16 Pro Max, 15 Pro Max |
+| `iPhone6_7` | 1290x2796 | iPhone 15/14/13 Pro Max, Plus |
+| `iPhone6_5` | 1242x2688 | iPhone 11 Pro Max, XS Max |
+| `iPhone6_1` | 1179x2556 | iPhone 16/15/14/13 Pro |
+| `iPhone5_5` | 1242x2208 | iPhone 8 Plus, 7 Plus |
+| `iPadPro13` | 2064x2752 | iPad Pro 13" M4 |
+| `iPadPro12_9` | 2048x2732 | iPad Pro 12.9" |
+| `iPadPro11` | 1668x2388 | iPad Pro 11" |
+
+Custom: `output_size: [1320, 2868]`

--- a/skills/koubou/capabilities-reference.md
+++ b/skills/koubou/capabilities-reference.md
@@ -1,0 +1,246 @@
+# Capabilities Reference
+
+Complete reference of everything koubou can do. The skill primarily uses HTML template mode, but this documents all capabilities for context.
+
+## Two Generation Modes
+
+### 1. HTML Template Mode (recommended for skill)
+
+Free-form design with HTML/CSS. Templates receive `{{variables}}` for text and `{{assets}}` for pre-rendered images (screenshot composited inside device frame).
+
+```yaml
+screenshots:
+  slide_1:
+    template: "templates/hero.html"
+    variables:
+      headline: "Your Text"
+    assets:
+      app_screenshot: "screenshots/home.png"
+```
+
+### 2. Content YAML Mode (programmatic)
+
+Items positioned by coordinates. Useful for simple layouts without HTML.
+
+```yaml
+screenshots:
+  slide_1:
+    background:
+      type: linear
+      colors: ["#1a1a2e", "#0f3460"]
+      direction: 180
+    content:
+      - type: text
+        content: "Your Headline"
+        position: ["50%", "15%"]
+        size: 120
+        color: "#FFFFFF"
+        weight: bold
+      - type: image
+        asset: "screenshots/home.png"
+        position: ["50%", "65%"]
+        scale: 0.6
+        frame: true
+```
+
+## Content Item Types (YAML mode)
+
+### text
+
+```yaml
+- type: text
+  content: "Hello World"
+  position: ["50%", "50%"]       # X, Y as % or px
+  size: 48                       # Font size in pixels
+  color: "#FFFFFF"               # Solid color (hex)
+  # OR
+  gradient:                      # Gradient text fill
+    type: linear
+    colors: ["#FF6B6B", "#4ECDC4"]
+    direction: 45
+  weight: "bold"                 # normal, bold, or numeric (100-900)
+  font_family: "Arial"           # Font family
+  alignment: "center"            # left, center, right
+  max_width: 1000                # Max width for wrapping (px)
+  max_lines: 2                   # Max number of lines
+  max_height: 300                # Max height budget (px)
+  min_size: 24                   # Min font size for auto-sizing
+  line_height: 1.2               # Line height multiplier
+  rotation: 15                   # Clockwise rotation in degrees
+  stroke_width: 3                # Text outline width
+  stroke_color: "#000000"        # Solid stroke color
+  # OR
+  stroke_gradient:               # Gradient stroke
+    type: linear
+    colors: ["#FF0000", "#0000FF"]
+```
+
+**Auto-sizing**: Set `min_size` + `max_width` + `max_height`. Koubou starts at `size` and shrinks to `min_size` until the text fits within the height budget.
+
+### image
+
+```yaml
+- type: image
+  asset: "screenshots/home.png"  # Image path
+  position: ["50%", "60%"]       # Center position
+  scale: 0.6                     # Scale factor
+  frame: true                    # Apply device frame
+  rotation: -5                   # Clockwise rotation in degrees
+```
+
+Asset path supports localization:
+- **String**: Convention-based (`screenshots/home.png` resolves to `screenshots/{lang}/home.png`)
+- **Dict**: Explicit per-language paths
+
+```yaml
+  asset:
+    en: "screenshots/en/home.png"
+    es: "screenshots/es/home.png"
+    default: "screenshots/home.png"
+```
+
+### highlight
+
+Annotation overlays drawn on top of images.
+
+```yaml
+- type: highlight
+  shape: "rounded_rect"          # circle, rounded_rect, rect
+  position: ["50%", "40%"]       # Center position
+  dimensions: ["30%", "10%"]     # Width, height (% or px)
+  border_color: "#FF0000"        # Border color
+  border_width: 4                # Border width in px
+  fill_color: "#FF000020"        # Fill with alpha
+  corner_radius: 16              # For rounded_rect
+
+  # Shadow
+  shadow: true
+  shadow_color: "#00000040"
+  shadow_blur: 15
+  shadow_offset: ["0", "6"]
+
+  # Spotlight mode (dims everything outside)
+  spotlight: true
+  spotlight_color: "#000000"
+  spotlight_opacity: 0.5
+
+  # Blur background (blur non-highlighted area)
+  blur_background: true
+  blur_radius: 20
+```
+
+### zoom
+
+Magnified callout that crops a region and shows it enlarged.
+
+```yaml
+- type: zoom
+  source_position: ["30%", "40%"]   # Center of area to magnify
+  source_size: ["15%", "10%"]       # Size of source crop
+  display_position: ["70%", "30%"]  # Where magnified view appears
+  display_size: ["40%", "30%"]      # Size of magnified bubble
+  # OR
+  zoom_level: 2.5                   # Auto-calc display_size from source_size * zoom_level
+
+  shape: "circle"                   # circle, rounded_rect, rect
+  border_color: "#FFFFFF"
+  border_width: 3
+  corner_radius: 16
+
+  # Source indicator
+  source_indicator: true
+  source_indicator_style: "border"  # border, dashed, fill
+
+  # Connector line
+  connector: true
+  connector_color: "#FFFFFF"
+  connector_width: 2
+  connector_style: "curved"         # straight, curved, facing
+  connector_fill: "#FFFFFF20"       # Fill between facing lines
+
+  # Shadow
+  shadow: true
+  shadow_color: "#00000040"
+  shadow_blur: 15
+```
+
+## Gradients
+
+Supported everywhere (backgrounds, text fill, text stroke).
+
+### Types
+
+```yaml
+# Solid
+background:
+  type: solid
+  colors: ["#1a1a2e"]
+
+# Linear
+background:
+  type: linear
+  colors: ["#1a1a2e", "#0f3460", "#e94560"]
+  positions: [0.0, 0.5, 1.0]    # Optional color stops
+  direction: 180                  # Degrees (0=top, 90=right, 180=bottom)
+
+# Radial
+background:
+  type: radial
+  colors: ["#667eea", "#764ba2"]
+  center: ["50%", "50%"]         # Center point
+  radius: "70%"                  # Radius
+
+# Conic
+background:
+  type: conic
+  colors: ["#FF0000", "#00FF00", "#0000FF", "#FF0000"]
+  center: ["50%", "50%"]
+  start_angle: 0                 # Starting angle in degrees
+```
+
+## Layer Order
+
+Content items render in this order (back to front):
+
+1. **Background** (solid, gradient)
+2. **Images** (in YAML order — first = bottom layer)
+3. **Highlights** (annotations on top of images)
+4. **Zooms** (magnified callouts)
+5. **Text** (always on top)
+
+## CLI Reference
+
+```bash
+# Generate screenshots
+kou generate config.yaml
+kou generate config.yaml --verbose
+kou generate config.yaml --output json
+
+# Live editing (watch for changes, auto-regenerate)
+kou live config.yaml
+kou live config.yaml --debounce 0.5 --verbose
+
+# List available App Store sizes
+kou list-sizes
+kou list-sizes --output json
+
+# List available device frames
+kou list-frames
+kou list-frames "iPhone 16"
+kou list-frames "iPad" --output json
+
+# Create sample config
+kou --create-config sample.yaml
+kou --create-config sample.yaml --name "My App" --force
+
+# Version
+kou --version
+```
+
+### Output formats
+
+All list/generate commands support `--output json` for machine-readable output (useful for automation). Default is `table` (human-readable rich output).
+
+### Live mode
+
+`kou live` watches the config file and all referenced assets. When anything changes, it regenerates only the affected screenshots. Use `--debounce` to control the delay before regeneration (default 0.5s).

--- a/skills/koubou/design-guide.md
+++ b/skills/koubou/design-guide.md
@@ -1,0 +1,398 @@
+# Design Guide
+
+## Narrative Arc Framework
+
+Plan slides as a story, not a feature list.
+
+| # | Role | What to show | Notes |
+|---|------|-------------|-------|
+| 1 | **Hero/Hook** | Main value proposition. "What does this app solve?" | App icon + tagline. 80% of users only see this one |
+| 2 | **Differentiator** | Star feature. What sets it apart from competitors | The unique selling point |
+| 3 | **Ecosystem** | Widgets, extensions, watch, integrations | Breadth of the product |
+| 4+ | **Core Features** | One feature per slide, prioritized by importance | One focus per screenshot |
+| Second-to-last | **Trust Signal** | Brand identity: "made for people who [X]" | Emotional connection |
+| Last | **More Features** | Extra features in pill/list format, "coming soon" | Expanded closing |
+
+**Critical**: Only the first 3 slides are visible in App Store search results without tapping into the listing. They must tell a complete story on their own.
+
+## Copywriting Rules
+
+### Iron rules
+
+- **One idea per headline** — never join concepts with "and"/"y"
+- **Simple vocabulary** — prefer 1-2 syllable words
+- **3-5 words per line** — readable in App Store thumbnail
+- **Arm test**: if you can't read it at arm's length, the text is too small
+- **Intentional line breaks** — control wraps with `<br>` when needed
+
+### Three approaches (choose per slide)
+
+1. **Paint a moment** — "Check your coffee without opening the app"
+2. **Declare an outcome** — "A home for every coffee you buy"
+3. **Kill a pain** — "Never waste a great bag of coffee"
+
+### What NOT to write
+
+- Headlines that are feature lists
+- Compound ideas joined with "and"
+- Buzzwords without substance ("AI-powered", "revolutionary")
+- More than 2 lines of text per screenshot
+
+## CSS Rules for Templates
+
+### Typography
+
+- **Headline**: 100-140px font-size
+- **Subtitle**: 50-65px font-size
+- **Font stack**: `-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", "Helvetica Neue", sans-serif`
+- **Font weight**: 700-800 for headlines, 400-500 for subtitles
+- **Color**: White text on dark backgrounds. Never gray on gray
+
+### Backgrounds
+
+- Use CSS gradients. Avoid flat solids
+- Vary gradients between slides (direction, colors, type)
+- Derive gradient colors from the app's brand palette
+- Dark backgrounds with light text perform best in App Store
+
+### Device placement
+
+- Width: 70-80% of viewport width
+- The `{{asset_name}}` in templates receives the screenshot already composited inside the device frame — just use `<img>` to place it
+- Always leave margin between device and edges (minimum 3-5% of viewport)
+
+### Layout variation (mandatory)
+
+NEVER repeat the same layout in consecutive slides. Alternate between:
+
+1. **Hero**: Text top, device bottom (centered)
+2. **Feature-top**: Device top, text bottom
+3. **Feature-side**: Device and text side by side
+4. **Contrast**: Text only, no device (bold statement slide)
+
+### Visual rhythm
+
+- Alternate light and dark backgrounds
+- Include 1-2 contrast slides (no device, just text)
+- One focal point per screenshot — never overload
+
+## What NOT to do
+
+- Text smaller than 50px (invisible in thumbnail)
+- Same layout on all screenshots
+- More than 2 lines of text per screenshot
+- Device touching the edge without margin
+- Colors outside the brand palette
+- Showing features that don't exist in the app
+- Flat white or black backgrounds without gradient
+- Stacking multiple devices on one slide (unless deliberately showing ecosystem)
+
+## HTML Template Examples
+
+All templates use viewport-sized layouts. Koubou sets the viewport to the exact App Store dimensions (e.g., 1320x2868 for iPhone6_9).
+
+### Hero Template (text top, device bottom)
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: linear-gradient(180deg, {{bg_start}} 0%, {{bg_end}} 100%);
+  }
+  .text-area {
+    padding-top: 12%;
+    text-align: center;
+    flex-shrink: 0;
+  }
+  h1 {
+    font-size: 120px;
+    font-weight: 800;
+    color: white;
+    line-height: 1.1;
+    margin-bottom: 24px;
+  }
+  p {
+    font-size: 56px;
+    font-weight: 400;
+    color: rgba(255,255,255,0.85);
+    line-height: 1.3;
+  }
+  .device-area {
+    margin-top: auto;
+    padding-bottom: 0;
+    display: flex;
+    justify-content: center;
+  }
+  .device-area img {
+    width: 75%;
+    height: auto;
+    object-fit: contain;
+  }
+</style>
+</head>
+<body>
+  <div class="text-area">
+    <h1>{{headline}}</h1>
+    <p>{{subtitle}}</p>
+  </div>
+  <div class="device-area">
+    <img src="{{app_screenshot}}">
+  </div>
+</body>
+</html>
+```
+
+### Feature-Top Template (device top, text bottom)
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: linear-gradient(160deg, {{bg_start}} 0%, {{bg_end}} 100%);
+  }
+  .device-area {
+    padding-top: 5%;
+    display: flex;
+    justify-content: center;
+  }
+  .device-area img {
+    width: 72%;
+    height: auto;
+    object-fit: contain;
+  }
+  .text-area {
+    margin-top: auto;
+    margin-bottom: 6%;
+    text-align: center;
+    padding: 0 8%;
+  }
+  h1 {
+    font-size: 110px;
+    font-weight: 800;
+    color: white;
+    line-height: 1.1;
+    margin-bottom: 20px;
+  }
+  p {
+    font-size: 54px;
+    font-weight: 400;
+    color: rgba(255,255,255,0.8);
+    line-height: 1.3;
+  }
+</style>
+</head>
+<body>
+  <div class="device-area">
+    <img src="{{app_screenshot}}">
+  </div>
+  <div class="text-area">
+    <h1>{{headline}}</h1>
+    <p>{{subtitle}}</p>
+  </div>
+</body>
+</html>
+```
+
+### Feature-Side Template (device left, text right)
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background: linear-gradient(135deg, {{bg_start}} 0%, {{bg_mid}} 50%, {{bg_end}} 100%);
+  }
+  .device-area {
+    width: 55%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 5%;
+  }
+  .device-area img {
+    width: 90%;
+    height: auto;
+    object-fit: contain;
+  }
+  .text-area {
+    width: 45%;
+    padding-right: 6%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  h1 {
+    font-size: 100px;
+    font-weight: 800;
+    color: white;
+    line-height: 1.1;
+    margin-bottom: 20px;
+  }
+  p {
+    font-size: 50px;
+    font-weight: 400;
+    color: rgba(255,255,255,0.8);
+    line-height: 1.3;
+  }
+</style>
+</head>
+<body>
+  <div class="device-area">
+    <img src="{{app_screenshot}}">
+  </div>
+  <div class="text-area">
+    <h1>{{headline}}</h1>
+    <p>{{subtitle}}</p>
+  </div>
+</body>
+</html>
+```
+
+### Contrast Template (text only, no device)
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(180deg, {{bg_start}} 0%, {{bg_end}} 100%);
+    text-align: center;
+    padding: 0 10%;
+  }
+  h1 {
+    font-size: 140px;
+    font-weight: 800;
+    color: white;
+    line-height: 1.15;
+    margin-bottom: 32px;
+  }
+  p {
+    font-size: 60px;
+    font-weight: 400;
+    color: rgba(255,255,255,0.75);
+    line-height: 1.3;
+  }
+</style>
+</head>
+<body>
+  <h1>{{headline}}</h1>
+  <p>{{subtitle}}</p>
+</body>
+</html>
+```
+
+### Feature List Template (pills/badges for "more features" slide)
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(180deg, {{bg_start}} 0%, {{bg_end}} 100%);
+    text-align: center;
+    padding: 0 8%;
+  }
+  h1 {
+    font-size: 110px;
+    font-weight: 800;
+    color: white;
+    line-height: 1.1;
+    margin-bottom: 60px;
+  }
+  .pills {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 24px;
+    max-width: 90%;
+  }
+  .pill {
+    background: rgba(255,255,255,0.15);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255,255,255,0.25);
+    border-radius: 60px;
+    padding: 28px 56px;
+    font-size: 48px;
+    font-weight: 600;
+    color: white;
+    white-space: nowrap;
+  }
+</style>
+</head>
+<body>
+  <h1>{{headline}}</h1>
+  <div class="pills">
+    <span class="pill">{{feature_1}}</span>
+    <span class="pill">{{feature_2}}</span>
+    <span class="pill">{{feature_3}}</span>
+    <span class="pill">{{feature_4}}</span>
+    <span class="pill">{{feature_5}}</span>
+    <span class="pill">{{feature_6}}</span>
+  </div>
+</body>
+</html>
+```
+
+## Adapting Templates
+
+These are starting points. For each project, adapt:
+
+- **Gradient colors**: Match brand palette
+- **Font sizes**: Scale based on text length (shorter text → larger font)
+- **Device image width**: Adjust between 65-85% based on how much screen real estate the device needs
+- **Spacing**: Adjust padding percentages based on text/device balance
+- **Additional elements**: Add app icons, floating UI elements, or badges as extra `<img>` tags using additional asset variables

--- a/skills/koubou/setup.md
+++ b/skills/koubou/setup.md
@@ -1,0 +1,73 @@
+# Setup Guide
+
+## Installation
+
+### Quick install (recommended)
+
+```bash
+pip3 install "koubou[html]"
+playwright install chromium
+```
+
+The `[html]` extra installs Playwright for HTML template rendering.
+
+### Verify installation
+
+```bash
+kou --version
+kou list-frames "iPhone 16"
+```
+
+### Alternative: install from source
+
+```bash
+git clone https://github.com/bitomule/Koubou.git /tmp/koubou
+cd /tmp/koubou
+pip3 install ".[html]"
+playwright install chromium
+```
+
+## Troubleshooting
+
+### `playwright install chromium` fails
+
+Try installing system Chrome instead — koubou tries system Chrome first before falling back to Playwright's bundled Chromium.
+
+```bash
+# macOS
+brew install --cask google-chrome
+```
+
+### `ModuleNotFoundError: No module named 'playwright'`
+
+You installed koubou without the HTML extra:
+
+```bash
+pip3 install "koubou[html]"
+```
+
+### `No browser available for HTML rendering`
+
+Neither system Chrome nor Playwright Chromium is available:
+
+```bash
+playwright install chromium
+# or install Chrome manually
+```
+
+### Permission errors on macOS
+
+```bash
+pip3 install --user "koubou[html]"
+```
+
+### Virtual environment
+
+If the project uses a `.venv`:
+
+```bash
+.venv/bin/pip install "koubou[html]"
+.venv/bin/playwright install chromium
+```
+
+Then run koubou with `.venv/bin/kou` instead of `kou`.

--- a/skills/koubou/yaml-reference.md
+++ b/skills/koubou/yaml-reference.md
@@ -1,0 +1,256 @@
+# YAML Config Reference
+
+## Minimal config (HTML template mode)
+
+```yaml
+project:
+  name: "My App"
+  output_dir: "output"
+  device: "iPhone 16 Pro - Black Titanium - Portrait"
+  output_size: "iPhone6_9"
+
+screenshots:
+  01_hero:
+    template: "templates/hero.html"
+    variables:
+      headline: "Your Headline"
+      subtitle: "Your subtitle text"
+    assets:
+      app_screenshot: "screenshots/home.png"
+```
+
+## Project section
+
+```yaml
+project:
+  name: "App Name"                                        # Project name
+  output_dir: "output"                                    # Where screenshots go
+  device: "iPhone 16 Pro - Black Titanium - Portrait"     # Device frame to use
+  output_size: "iPhone6_9"                                # App Store size (or [width, height])
+```
+
+`output_size` accepts named sizes or custom `[width, height]` arrays. See sizes table below.
+
+## Screenshots section
+
+Each key under `screenshots:` is a screenshot ID (used as filename).
+
+### HTML template mode (recommended)
+
+```yaml
+screenshots:
+  01_hero:
+    template: "templates/hero.html"        # Path to HTML template
+    variables:                             # Text — localizable via xcstrings
+      headline: "Clean Your iPhone"
+      subtitle: "Free up space instantly"
+    assets:                                # Images — pre-rendered with device frame
+      app_screenshot: "screenshots/home.png"
+```
+
+### variables vs assets
+
+| Field | Template syntax | What it does | Localized? |
+|-------|----------------|-------------|-----------|
+| `variables` | `{{key}}` | Text substitution | Yes (via xcstrings) |
+| `assets` | `{{key}}` | Image path, pre-rendered with device frame | Via directory convention |
+
+Both use `{{key}}` in the HTML. The difference:
+- **variables**: Pure text replacement. Values are extracted as xcstrings keys for localization
+- **assets**: File paths. Koubou pre-renders each image with the configured device frame, then symlinks the composited image into the template sandbox
+
+### Disabling device frame
+
+By default, all image assets get the device frame applied. To disable per-screenshot:
+
+```yaml
+  fullscreen_slide:
+    template: "templates/contrast.html"
+    frame: false                          # No device frame for this slide
+    variables:
+      headline: "Bold Statement"
+```
+
+## Defaults section (optional)
+
+```yaml
+defaults:
+  background:
+    type: linear
+    colors: ["#1a1a2e", "#16213e"]
+    direction: 180
+```
+
+Applied to content-mode screenshots that don't specify their own background. Not used by HTML template mode (templates define their own backgrounds in CSS).
+
+## Localization
+
+```yaml
+localization:
+  base_language: "en"
+  languages: ["en", "es", "de", "ja"]
+  xcstrings_path: "koubou-strings.xcstrings"
+```
+
+### How text localization works
+
+1. All `variables` values are extracted as localization keys
+2. Koubou creates/updates the xcstrings file with these keys
+3. Base language gets the value as-is with `state: "translated"`
+4. Other languages get empty values with `state: "needs_translation"`
+5. Edit translations in Xcode or any xcstrings editor
+6. On generation, koubou substitutes the translated text for each language
+
+### How asset localization works
+
+**Convention-based** (recommended): Place localized screenshots in language subdirectories.
+
+```
+screenshots/
+  en/
+    home.png
+    features.png
+  es/
+    home.png
+    features.png
+```
+
+Config just references the base path — koubou resolves `screenshots/home.png` to `screenshots/{lang}/home.png` automatically:
+
+```yaml
+assets:
+  app_screenshot: "screenshots/home.png"
+```
+
+Resolution order: `screenshots/{current_lang}/home.png` → `screenshots/{base_lang}/home.png` → `screenshots/home.png`
+
+**Explicit mapping** (content mode only):
+
+```yaml
+asset:
+  en: "screenshots/en/home.png"
+  es: "screenshots/es/home.png"
+  default: "screenshots/home.png"
+```
+
+### Localized output structure
+
+```
+output/
+  en/
+    iPhone_16_Pro_-_Black_Titanium_-_Portrait/
+      01_hero.png
+      02_feature.png
+  es/
+    iPhone_16_Pro_-_Black_Titanium_-_Portrait/
+      01_hero.png
+      02_feature.png
+```
+
+## Complete example
+
+```yaml
+project:
+  name: "Undolly"
+  output_dir: "AppStore/output"
+  device: "iPhone 16 Pro - Black Titanium - Portrait"
+  output_size: "iPhone6_9"
+
+localization:
+  base_language: "en"
+  languages: ["en", "es"]
+  xcstrings_path: "AppStore/koubou-strings.xcstrings"
+
+screenshots:
+  01_hero:
+    template: "AppStore/templates/hero.html"
+    variables:
+      headline: "Find Duplicate Photos"
+      subtitle: "Free up gigabytes of space"
+      bg_start: "#1a1a2e"
+      bg_end: "#0f3460"
+    assets:
+      app_screenshot: "screenshots/home.png"
+
+  02_scan:
+    template: "AppStore/templates/feature_top.html"
+    variables:
+      headline: "Smart Scanning"
+      subtitle: "AI-powered duplicate detection"
+      bg_start: "#0f3460"
+      bg_end: "#1a1a2e"
+    assets:
+      app_screenshot: "screenshots/scan.png"
+
+  03_results:
+    template: "AppStore/templates/feature_side.html"
+    variables:
+      headline: "Review Results"
+      subtitle: "Keep what matters"
+      bg_start: "#1a1a2e"
+      bg_mid: "#162447"
+      bg_end: "#1b1b3a"
+    assets:
+      app_screenshot: "screenshots/results.png"
+
+  04_statement:
+    template: "AppStore/templates/contrast.html"
+    frame: false
+    variables:
+      headline: "Your Photos, Organized"
+      subtitle: "Made for people who care"
+      bg_start: "#0f3460"
+      bg_end: "#1a1a2e"
+
+  05_more:
+    template: "AppStore/templates/features_list.html"
+    frame: false
+    variables:
+      headline: "And So Much More"
+      feature_1: "iCloud Sync"
+      feature_2: "Batch Delete"
+      feature_3: "Smart Albums"
+      feature_4: "Privacy First"
+      feature_5: "No Ads"
+      feature_6: "Widgets"
+      bg_start: "#1a1a2e"
+      bg_end: "#0f3460"
+```
+
+## Devices
+
+### Recommended defaults
+
+| Use case | Device name | Output size |
+|----------|------------|-------------|
+| iPhone (standard) | `iPhone 16 Pro - Black Titanium - Portrait` | `iPhone6_9` |
+| iPhone (max) | `iPhone 16 Pro Max - Black Titanium - Portrait` | `iPhone6_9` |
+| iPad | `iPad Pro 13 - M4 - Space Gray - Portrait` | `iPadPro13` |
+
+### Finding device names
+
+```bash
+kou list-frames                    # All available frames (100+)
+kou list-frames "iPhone 16"        # Filter by search term
+kou list-frames "iPad"             # iPad frames
+kou list-frames --output json      # Machine-readable
+```
+
+Device names must match exactly as shown by `kou list-frames`.
+
+## App Store Sizes
+
+| Name | Dimensions | Devices |
+|------|-----------|---------|
+| `iPhone6_9` | 1320x2868 | iPhone 16 Pro Max, 15 Pro Max (6.9") |
+| `iPhone6_7` | 1290x2796 | iPhone 15/14/13/12 Pro Max, Plus (6.7") |
+| `iPhone6_5` | 1242x2688 | iPhone 11 Pro Max, XS Max (6.5") |
+| `iPhone6_1` | 1179x2556 | iPhone 16/15/14/13 Pro, 12 Pro, 11, XR (6.1") |
+| `iPhone5_5` | 1242x2208 | iPhone 8 Plus, 7 Plus, 6s Plus (5.5") |
+| `iPadPro13` | 2064x2752 | iPad Pro 13" M4, iPad Air 13" M2 |
+| `iPadPro12_9` | 2048x2732 | iPad Pro 12.9" (3rd gen and later) |
+| `iPadPro11` | 1668x2388 | iPad Pro 11", iPad Air 11" M2 |
+
+List all: `kou list-sizes`
+
+Custom dimensions: `output_size: [1320, 2868]`


### PR DESCRIPTION
## Summary

- Adds a Claude Code skill (`skills/koubou/`) that guides users through generating professional App Store screenshots conversationally
- 5 files: SKILL.md (entry point + 3-phase flow), setup.md, design-guide.md, yaml-reference.md, capabilities-reference.md
- Supports `npx skills add bitomule/Koubou` installation via standard `skills/` directory convention

## What the skill does

1. **Setup**: Silently installs koubou + Playwright if missing
2. **Gather info**: Conversational flow — auto-detects existing screenshots, derives brand colors from project assets, asks only what's missing
3. **Generate**: Creates varied HTML templates + YAML config, runs `kou generate`, opens output, iterates on feedback

## Test plan

- [ ] Install skill: `cp -r skills/koubou ~/.claude/skills/koubou`
- [ ] Open new Claude Code session
- [ ] Invoke `/koubou` and verify it loads
- [ ] Test with a real project (e.g., "generate screenshots for Undolly")
- [ ] Verify: device frames applied, Apple dimensions correct, layouts varied, copy professional
- [ ] Request adjustments and verify iteration works