### PR TITLE
Improve koubou skill and refresh Undolly example

### DIFF
--- a/examples/undolly/config.yaml
+++ b/examples/undolly/config.yaml
@@ -8,23 +8,35 @@ screenshots:
   01_hero:
     template: "templates/hero.html"
     variables:
-      headline: "Clean Your iPhone"
-      subtitle: "Free up space instantly"
+      headline: "Free Up Space Fast"
+      subtitle: "Clear similar photos in minutes"
     assets:
       app_screenshot: "screenshots/home_dashboard.png"
 
   02_find_duplicates:
     template: "templates/feature.html"
     variables:
-      headline: "Find Duplicates"
-      subtitle: "AI groups similar photos"
+      headline: "Compare Similar Shots"
+      subtitle: "Keep one and delete the rest"
     assets:
       app_screenshot: "screenshots/group_clean.png"
 
   03_smart_analysis:
-    template: "templates/hero.html"
+    template: "templates/analysis.html"
     variables:
-      headline: "Smart Analysis"
-      subtitle: "Keep the best shots"
+      headline: "Keep Only The Best"
+      subtitle: "Sharpness, framing, and eyes open"
     assets:
       app_screenshot: "screenshots/group_detailed.png"
+
+  04_more_features:
+    template: "templates/features_list.html"
+    frame: false
+    variables:
+      headline: "Clean The Whole Library"
+      feature_1: "Similar Photos"
+      feature_2: "Big Videos"
+      feature_3: "Screenshots"
+      feature_4: "WhatsApp Media"
+      feature_5: "Best Shot"
+      feature_6: "Framing"

--- a/examples/undolly/templates/analysis.html
+++ b/examples/undolly/templates/analysis.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", sans-serif;
+    background:
+      radial-gradient(circle at 20% 18%, rgba(255, 186, 84, 0.22), transparent 26%),
+      radial-gradient(circle at 82% 82%, rgba(93, 126, 255, 0.22), transparent 28%),
+      linear-gradient(145deg, #081027 0%, #10245d 50%, #2740a3 100%);
+  }
+  .canvas {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6% 4.2% 6% 6%;
+    gap: 1%;
+  }
+  .copy {
+    width: 38%;
+    align-self: flex-start;
+    padding-top: 1%;
+    z-index: 2;
+  }
+  h1 {
+    color: #ffffff;
+    font-size: 144px;
+    font-weight: 800;
+    line-height: 0.92;
+    letter-spacing: -0.065em;
+    text-wrap: balance;
+  }
+  p {
+    margin-top: 18px;
+    color: rgba(237, 240, 255, 0.84);
+    font-size: 56px;
+    font-weight: 500;
+    line-height: 1.12;
+    text-wrap: balance;
+    max-width: 92%;
+  }
+  .stack {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 32px;
+    max-width: 92%;
+  }
+  .pill {
+    padding: 22px 26px;
+    border-radius: 28px;
+    color: #ffffff;
+    font-size: 34px;
+    font-weight: 700;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    backdrop-filter: blur(16px);
+  }
+  .device-area {
+    position: relative;
+    width: 64%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .device-area::before {
+    content: "";
+    position: absolute;
+    bottom: 12%;
+    width: 88%;
+    height: 18%;
+    border-radius: 999px;
+    background: radial-gradient(circle, rgba(72, 109, 255, 0.42), transparent 68%);
+    filter: blur(28px);
+  }
+  .device {
+    position: relative;
+    z-index: 2;
+    width: 124%;
+    transform: translateX(16%) rotate(10deg) translateY(4%);
+    transform-origin: center center;
+    filter: drop-shadow(0 36px 72px rgba(5, 10, 31, 0.45));
+  }
+  .device img {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+</style>
+</head>
+<body>
+  <div class="canvas">
+    <div class="copy">
+      <h1>{{headline}}</h1>
+      <p>{{subtitle}}</p>
+      <div class="stack">
+        <div class="pill">Sharpness check</div>
+        <div class="pill">Eyes open first</div>
+        <div class="pill">Framing included</div>
+      </div>
+    </div>
+    <div class="device-area">
+      <div class="device">
+        <img src="{{app_screenshot}}">
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/undolly/templates/feature.html
+++ b/examples/undolly/templates/feature.html
@@ -1,51 +1,99 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="utf-8">
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
     width: 100vw;
     height: 100vh;
-    background: radial-gradient(circle at 30% 20%, #ff6b35, #f7931e, #d64000);
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", sans-serif;
+    background:
+      radial-gradient(circle at 18% 18%, rgba(255, 225, 126, 0.32), transparent 24%),
+      radial-gradient(circle at 84% 78%, rgba(255, 122, 24, 0.24), transparent 28%),
+      linear-gradient(180deg, #ffb138 0%, #ff7a00 62%, #d65300 100%);
+  }
+  .canvas {
+    width: 100%;
+    height: 100%;
+    padding: 4.5% 5.2% 5.2%;
     display: flex;
     flex-direction: column;
     align-items: center;
-    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
-    overflow: hidden;
+  }
+  .device-area {
+    position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    margin-top: 0.5%;
+  }
+  .device-area::before {
+    content: "";
+    position: absolute;
+    bottom: 8%;
+    width: 82%;
+    height: 14%;
+    border-radius: 999px;
+    background: radial-gradient(circle, rgba(120, 39, 0, 0.38), transparent 70%);
+    filter: blur(30px);
   }
   .device {
-    margin-top: 5%;
-    width: 75%;
+    position: relative;
+    z-index: 2;
+    width: 90%;
+    transform: rotate(3deg) translateY(1%);
+    transform-origin: center center;
+    filter: drop-shadow(0 34px 66px rgba(115, 35, 0, 0.34));
   }
   .device img {
     width: 100%;
     height: auto;
+    display: block;
   }
-  .text-block {
+  .text-card {
     margin-top: auto;
-    margin-bottom: 6%;
-    text-align: center;
+    width: 100%;
+    padding: 44px 46px 48px;
+    border-radius: 50px;
+    background: rgba(126, 39, 0, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    backdrop-filter: blur(18px);
+    box-shadow: 0 24px 46px rgba(130, 36, 2, 0.18);
+    text-align: left;
   }
-  .headline {
+  h1 {
     color: #ffffff;
-    font-size: 130px;
+    font-size: 132px;
     font-weight: 800;
-    line-height: 1.1;
+    line-height: 0.92;
+    letter-spacing: -0.06em;
+    text-wrap: balance;
+    max-width: 92%;
   }
-  .subtitle {
-    color: #f0f0f0;
-    font-size: 58px;
-    margin-top: 2%;
+  p {
+    margin-top: 18px;
+    color: rgba(255, 247, 239, 0.86);
+    font-size: 56px;
+    font-weight: 500;
+    line-height: 1.12;
+    max-width: 88%;
+    text-wrap: balance;
   }
 </style>
 </head>
 <body>
-  <div class="device">
-    <img src="{{app_screenshot}}">
-  </div>
-  <div class="text-block">
-    <h1 class="headline">{{headline}}</h1>
-    <p class="subtitle">{{subtitle}}</p>
+  <div class="canvas">
+    <div class="device-area">
+      <div class="device">
+        <img src="{{app_screenshot}}">
+      </div>
+    </div>
+    <div class="text-card">
+      <h1>{{headline}}</h1>
+      <p>{{subtitle}}</p>
+    </div>
   </div>
 </body>
 </html>

--- a/examples/undolly/templates/features_list.html
+++ b/examples/undolly/templates/features_list.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    background:
+      radial-gradient(circle at 18% 18%, rgba(255, 168, 54, 0.18), transparent 22%),
+      radial-gradient(circle at 84% 18%, rgba(52, 105, 255, 0.22), transparent 24%),
+      radial-gradient(circle at 22% 82%, rgba(255, 168, 54, 0.12), transparent 24%),
+      linear-gradient(180deg, #0a1025 0%, #17285d 54%, #2944a9 100%);
+    text-align: center;
+    padding: 14% 7% 0;
+  }
+  .wrap {
+    width: 100%;
+    max-width: 1140px;
+  }
+  h1 {
+    font-size: 140px;
+    font-weight: 800;
+    color: white;
+    line-height: 0.96;
+    letter-spacing: -0.065em;
+    margin-bottom: 32px;
+    text-wrap: balance;
+  }
+  .subtitle {
+    font-size: 52px;
+    line-height: 1.14;
+    font-weight: 500;
+    color: rgba(236, 241, 255, 0.84);
+    margin: 0 auto 40px;
+    max-width: 74%;
+  }
+  .pills {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 24px;
+    max-width: 100%;
+  }
+  .pill {
+    background: rgba(255, 255, 255, 0.13);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    border-radius: 34px;
+    padding: 30px 34px;
+    font-size: 42px;
+    font-weight: 700;
+    color: white;
+    white-space: nowrap;
+  }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>{{headline}}</h1>
+    <p class="subtitle">Photos, videos, screenshots, and more</p>
+    <div class="pills">
+      <span class="pill">{{feature_1}}</span>
+      <span class="pill">{{feature_2}}</span>
+      <span class="pill">{{feature_3}}</span>
+      <span class="pill">{{feature_4}}</span>
+      <span class="pill">{{feature_5}}</span>
+      <span class="pill">{{feature_6}}</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/undolly/templates/hero.html
+++ b/examples/undolly/templates/hero.html
@@ -1,50 +1,109 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="utf-8">
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
     width: 100vw;
     height: 100vh;
-    background: linear-gradient(135deg, #0f0c29, #302b63, #24243e);
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", sans-serif;
+    background:
+      radial-gradient(circle at 22% 18%, rgba(255, 189, 76, 0.28), transparent 24%),
+      radial-gradient(circle at 84% 84%, rgba(60, 117, 255, 0.28), transparent 30%),
+      linear-gradient(180deg, #050814 0%, #121d4a 48%, #2442a7 100%);
+  }
+  .canvas {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    padding: 6% 6% 0;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
-    overflow: hidden;
+    align-items: flex-start;
   }
-  .headline {
-    color: #ffffff;
-    font-size: 130px;
+  .copy {
+    position: relative;
+    z-index: 3;
+    width: 72%;
+  }
+  h1 {
+    font-size: 148px;
+    line-height: 0.9;
+    letter-spacing: -0.065em;
     font-weight: 800;
-    text-align: center;
-    margin-top: 8%;
-    line-height: 1.1;
+    color: #ffffff;
+    text-wrap: balance;
     max-width: 90%;
   }
-  .subtitle {
-    color: #e0e0e0;
+  p {
+    margin-top: 24px;
     font-size: 58px;
-    text-align: center;
-    margin-top: 2%;
-    max-width: 85%;
+    line-height: 1.08;
+    font-weight: 500;
+    color: rgba(240, 244, 255, 0.86);
+    text-wrap: balance;
+    max-width: 78%;
+  }
+  .device-stage {
+    position: relative;
+    flex: 1;
+    width: 100%;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    margin-top: 1%;
+  }
+  .device-stage::before {
+    content: "";
+    position: absolute;
+    bottom: 5%;
+    right: 6%;
+    width: 72%;
+    height: 18%;
+    border-radius: 999px;
+    background: radial-gradient(circle, rgba(47, 104, 255, 0.48), transparent 68%);
+    filter: blur(32px);
+  }
+  .halo {
+    position: absolute;
+    bottom: 34%;
+    right: 11%;
+    width: 320px;
+    height: 320px;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(255, 178, 72, 0.46), transparent 70%);
+    filter: blur(12px);
+    z-index: 1;
   }
   .device {
-    margin-top: auto;
-    margin-bottom: -3%;
-    width: 75%;
+    position: relative;
+    z-index: 2;
+    width: 92%;
+    transform: translateX(12%) rotate(-8deg) translateY(14%);
+    transform-origin: center bottom;
+    filter: drop-shadow(0 42px 80px rgba(4, 8, 30, 0.52));
   }
   .device img {
     width: 100%;
     height: auto;
+    display: block;
   }
 </style>
 </head>
 <body>
-  <h1 class="headline">{{headline}}</h1>
-  <p class="subtitle">{{subtitle}}</p>
-  <div class="device">
-    <img src="{{app_screenshot}}">
+  <div class="canvas">
+    <div class="copy">
+      <h1>{{headline}}</h1>
+      <p>{{subtitle}}</p>
+    </div>
+    <div class="device-stage">
+      <div class="halo"></div>
+      <div class="device">
+        <img src="{{app_screenshot}}">
+      </div>
+    </div>
   </div>
 </body>
 </html>

--- a/skills/koubou/SKILL.md
+++ b/skills/koubou/SKILL.md
@@ -7,10 +7,7 @@ allowed-tools:
   - Edit
   - Glob
   - Grep
-  - Bash(pip *)
-  - Bash(pip3 *)
   - Bash(kou *)
-  - Bash(playwright *)
   - Bash(python *)
   - Bash(python3 *)
   - Bash(open *)
@@ -29,21 +26,35 @@ Generate professional App Store screenshots using HTML/CSS templates with 100+ r
 **User instructions always take priority over defaults in this skill.**
 
 Reference files (read as needed, not upfront):
-- `setup.md` — Installation of koubou + HTML rendering support
+- `setup.md` — Installation and HTML runtime setup
 - `design-guide.md` — Design principles, copywriting rules, CSS rules, HTML template examples
 - `yaml-reference.md` — YAML config format, localization, assets, devices, sizes
 - `capabilities-reference.md` — Full koubou capabilities (content mode, highlights, zoom, gradients)
 
 ## Phase 1: Setup (silent, automatic)
 
-Check if koubou is installed. If not, install it. Do not ask the user — just do it.
+Check if `kou` is available first. Do not reinstall or touch Python packaging if `kou` already works.
+
+Preferred order:
 
 ```bash
-command -v kou >/dev/null 2>&1 || pip3 install koubou
-kou setup-html 2>/dev/null || true
+kou --version 2>/dev/null
 ```
 
-Only inform the user if installation fails. Read `setup.md` for troubleshooting.
+If `kou --version` succeeds:
+- treat koubou as installed
+- do **not** run `pip`, `pip3`, or `playwright install`
+- do **not** try to "upgrade" or "fix" the user's environment proactively
+- always run `kou setup-html` before generating, because this skill is HTML-only and the command is designed to be safe to repeat
+
+If `kou --version` fails, read `setup.md` and follow the least invasive path for the environment.
+
+For HTML rendering support:
+- always use `kou setup-html`
+- do **not** skip it just because HTML worked in a previous run
+- do **not** run `playwright install chromium` directly
+
+Only inform the user if setup fails. Never mutate a working installation.
 
 ## Phase 2: Gather Information
 
@@ -56,16 +67,19 @@ Collect what you need through natural conversation. Do NOT dump all questions at
    - Glob for: `.maestro/`, `screenshots/`, `AppStore/`, `fastlane/screenshots/`, `marketing/`
    - If found, show what you found and confirm
    - If not found, ask how the user generates them
-3. **Visual style**: Brand colors (accent, background), dark/light/colorful preference
-   - If `Assets.xcassets`, `marketing/plan.md`, or prior marketing exists, derive colors from there without asking
+   - Prefer clean simulator captures that show the app UI clearly. If the user can choose, prefer recent 6.1-inch iPhone captures as the source material
+3. **Visual style**: Brand colors, preferred font, dark/light/colorful preference, and App Store references if any
+   - If `Assets.xcassets`, `marketing/plan.md`, prior marketing, or brand assets exist, derive colors/font direction from there without asking
 4. **Features to highlight**: Prioritized list of features/benefits (recommend 3-5). Each slide = 1 feature
-5. **Slide count**: How many screenshots (recommend 3-5 to start, Apple allows up to 10)
+5. **Hero assets**: App icon or other brand asset. Search automatically before asking
+6. **Slide count**: How many screenshots (recommend 3-5 to start, Apple allows up to 10)
 
 ### Optional (ask only if relevant)
 
-6. **Device**: Default is `iPhone 16 Pro - Black Titanium - Portrait`. Only ask if iPad/Mac/other makes sense
-7. **Localization**: Only if the project already has xcstrings or multiple language support
-8. **Extra assets**: App icon, floating UI elements, badges
+7. **Device**: Default is `iPhone 16 Pro - Black Titanium - Portrait`. Only ask if iPad/Mac/other makes sense
+8. **Localization**: Only if the project already has xcstrings or multiple language support
+9. **Extra assets**: Floating UI elements, badges, supporting illustrations
+10. **Additional constraints**: Any required claims, forbidden styles, or marketing constraints
 
 ### Derived (do NOT ask — figure out automatically)
 
@@ -73,6 +87,8 @@ Collect what you need through natural conversation. Do NOT dump all questions at
 - Layout distribution (hero → feature-top → feature-bottom → alternating)
 - Headline copy (from features and value proposition)
 - Secondary palette (variations of brand colors)
+- Whether the app name should appear in the slide at all. Default: omit it unless it adds real brand value at readable size
+- Whether the app icon should appear. Default: use it sparingly on hero or closing slides, not as a tiny decorative marker
 
 **Principle**: If context is available (CLAUDE.md, existing configs, marketing/plan.md, Assets.xcassets), use it without re-asking.
 
@@ -81,18 +97,34 @@ Collect what you need through natural conversation. Do NOT dump all questions at
 Read `design-guide.md` before generating templates. Read `yaml-reference.md` before writing config.
 
 1. Create working directory (e.g., `AppStore/` or wherever makes sense for the project)
-2. Create `templates/` with HTML templates — **minimum 3 distinct layouts** (read `design-guide.md` for templates)
-3. Create `config.yaml` with koubou config (read `yaml-reference.md` for format)
-4. Run: `kou generate config.yaml --setup-html --verbose`
-5. Open output folder: `open <output_dir>`
-6. Ask if the user wants adjustments — iterate on specific slides without regenerating everything
+2. Run `kou setup-html`
+3. Draft the narrative arc and 2-3 headline/subtitle options per slide before touching layout. Pick the strongest one first. Copy quality comes before CSS
+4. Create `templates/` with HTML templates — **minimum 3 distinct layouts** (read `design-guide.md` for templates)
+5. Create `config.yaml` with koubou config (read `yaml-reference.md` for format)
+6. Run: `kou generate config.yaml --verbose`
+7. Review the generated output against the rejection checklist in `design-guide.md`. If it fails, fix templates/copy and regenerate before showing it as final
+8. Open output folder: `open <output_dir>`
+9. Ask if the user wants adjustments — iterate on specific slides without regenerating everything
 
 ### Iteration Rules
 
 - When user asks to change a specific slide, only modify that template + config entry
 - When user asks for a global style change (colors, fonts), update all templates
-- Re-run `kou generate config.yaml --setup-html --verbose` after changes
-- Use `kou live config.yaml --setup-html` if user wants real-time preview while editing
+- Re-run `kou generate config.yaml --verbose` after changes
+- Use `kou live config.yaml` if user wants real-time preview while editing
+- Do not stop after the first successful render if the output still violates the design rules or rejection checklist
+
+## Hard Rules
+
+- Do not add tiny top labels, category labels, or app-name headers by default
+- Do not render the app name as small decorative text near the top unless it is clearly readable and strategically useful
+- Do not use app icons as tiny corner decorations; if used, they should behave like a real brand element
+- Do not use the same upright, centered phone composition on consecutive slides
+- Do not leave large empty bands between headline/subtitle and the device
+- Do not accept a slide where the device feels visually secondary
+- Do not use awkward, literal, or unnatural headlines just to be short
+- Do not start layout work before the slide narrative and copy are coherent
+- If the first 3 slides do not already feel App Store-ready, keep iterating before presenting them
 
 ## Key Technical Details
 

--- a/skills/koubou/design-guide.md
+++ b/skills/koubou/design-guide.md
@@ -6,7 +6,7 @@ Plan slides as a story, not a feature list.
 
 | # | Role | What to show | Notes |
 |---|------|-------------|-------|
-| 1 | **Hero/Hook** | Main value proposition. "What does this app solve?" | App icon + tagline. 80% of users only see this one |
+| 1 | **Hero/Hook** | Main value proposition. "What does this app solve?" | Optional app icon + strong tagline. 80% of users only see this one |
 | 2 | **Differentiator** | Star feature. What sets it apart from competitors | The unique selling point |
 | 3 | **Ecosystem** | Widgets, extensions, watch, integrations | Breadth of the product |
 | 4+ | **Core Features** | One feature per slide, prioritized by importance | One focus per screenshot |
@@ -14,6 +14,19 @@ Plan slides as a story, not a feature list.
 | Last | **More Features** | Extra features in pill/list format, "coming soon" | Expanded closing |
 
 **Critical**: Only the first 3 slides are visible in App Store search results without tapping into the listing. They must tell a complete story on their own.
+
+## Planning Before Layout
+
+- Write the full slide story first: slide role, headline, subtitle, screenshot choice
+- Do not start CSS until the first 3 slides already feel like a coherent ad campaign
+- Pick the strongest screenshot for the hero, not just the first one available
+- If the source captures are weak, cropped badly, or inconsistent, ask for better captures before polishing CSS forever
+
+## Source Material
+
+- Prefer clean simulator captures over noisy marketing exports
+- If the user can choose, prefer recent 6.1-inch iPhone captures as the source because they adapt cleanly across App Store compositions
+- Use screenshots with obvious focal points. Busy or low-contrast screens make the final slide weaker
 
 ## Copywriting Rules
 
@@ -23,6 +36,7 @@ Plan slides as a story, not a feature list.
 - **Simple vocabulary** — prefer 1-2 syllable words
 - **3-5 words per line** — readable in App Store thumbnail
 - **Arm test**: if you can't read it at arm's length, the text is too small
+- **One-second rule**: the headline should be understandable in about one second
 - **Intentional line breaks** — control wraps with `<br>` when needed
 
 ### Three approaches (choose per slide)
@@ -31,12 +45,20 @@ Plan slides as a story, not a feature list.
 2. **Declare an outcome** — "A home for every coffee you buy"
 3. **Kill a pain** — "Never waste a great bag of coffee"
 
+### Copy process
+
+1. Draft at least 2-3 headline directions before choosing one
+2. Prefer the simplest line that still feels premium and specific
+3. Read it at arm's length and apply the one-second rule
+4. Only then move on to layout
+
 ### What NOT to write
 
 - Headlines that are feature lists
 - Compound ideas joined with "and"
 - Buzzwords without substance ("AI-powered", "revolutionary")
 - More than 2 lines of text per screenshot
+- Tiny category labels pretending to be copy
 
 ## CSS Rules for Templates
 
@@ -47,6 +69,10 @@ Plan slides as a story, not a feature list.
 - **Font stack**: `-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", "Helvetica Neue", sans-serif`
 - **Font weight**: 700-800 for headlines, 400-500 for subtitles
 - **Color**: White text on dark backgrounds. Never gray on gray
+- Avoid micro-labels and eyebrow text by default. If a small label is not essential to the selling message, remove it
+- Do not put the app name as a tiny decorative line at the top. Either omit it or render it at a clearly intentional, readable size
+- If a line of text feels like a section title, category tag, or UI annotation instead of marketing copy, it probably should not be there
+- If an app icon is used, it should support the hero composition or closing brand moment, not act as a miniature badge in a corner
 
 ### Backgrounds
 
@@ -60,6 +86,9 @@ Plan slides as a story, not a feature list.
 - Width: 70-80% of viewport width
 - The `{{asset_name}}` in templates receives the screenshot already composited inside the device frame — just use `<img>` to place it
 - Always leave margin between device and edges (minimum 3-5% of viewport)
+- The device should feel primary, not like a thumbnail floating in empty space
+- At least one of the first three slides should use a more assertive composition: tilt, crop, off-center placement, or edge break
+- Do not keep every device perfectly upright and centered. Repetition kills the set
 
 ### Layout variation (mandatory)
 
@@ -76,6 +105,13 @@ NEVER repeat the same layout in consecutive slides. Alternate between:
 - Include 1-2 contrast slides (no device, just text)
 - One focal point per screenshot — never overload
 
+### Vertical spacing
+
+- Large empty bands between headline/subtitle and the device are a failure
+- Text and device should feel compositionally related, not stacked as two unrelated blocks
+- If the middle of the slide is mostly empty background, tighten the composition
+- Use scale, overlap, tilt, and block placement to remove dead space before adding more text
+
 ## What NOT to do
 
 - Text smaller than 50px (invisible in thumbnail)
@@ -86,6 +122,22 @@ NEVER repeat the same layout in consecutive slides. Alternate between:
 - Showing features that don't exist in the app
 - Flat white or black backgrounds without gradient
 - Stacking multiple devices on one slide (unless deliberately showing ecosystem)
+- Tiny top-left labels like "review flow", "smart cleanup", or a miniature app name with no strategic value
+- Consecutive slides where the phone sits in nearly the same posture and position
+- Huge gaps where neither the text nor the device owns the slide
+- Presenting the first technically successful render without a quality pass
+
+## Rejection Checklist
+
+Do not present screenshots as final until all of these are true:
+
+- The first 3 slides tell a complete product story on their own
+- No two consecutive slides use the same device posture and composition
+- The device feels like a hero element whenever a device is present
+- There are no large dead zones between copy and imagery
+- Headlines sound like marketing, not documentation or feature labels
+- There are no tiny decorative top labels unless the user explicitly asked for them
+- The set reads like App Store advertising, not an internal product deck
 
 ## HTML Template Examples
 
@@ -108,12 +160,14 @@ All templates use viewport-sized layouts. Koubou sets the viewport to the exact 
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: space-between;
     background: linear-gradient(180deg, {{bg_start}} 0%, {{bg_end}} 100%);
+    padding: 8% 6% 0;
   }
   .text-area {
-    padding-top: 12%;
     text-align: center;
     flex-shrink: 0;
+    max-width: 88%;
   }
   h1 {
     font-size: 120px;
@@ -129,15 +183,18 @@ All templates use viewport-sized layouts. Koubou sets the viewport to the exact 
     line-height: 1.3;
   }
   .device-area {
-    margin-top: auto;
-    padding-bottom: 0;
     display: flex;
     justify-content: center;
+    align-items: flex-end;
+    width: 100%;
+    margin-top: 3%;
   }
   .device-area img {
-    width: 75%;
+    width: 82%;
     height: auto;
     object-fit: contain;
+    transform: translateY(2%) rotate(-6deg);
+    transform-origin: bottom center;
   }
 </style>
 </head>
@@ -170,23 +227,26 @@ All templates use viewport-sized layouts. Koubou sets the viewport to the exact 
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: space-between;
     background: linear-gradient(160deg, {{bg_start}} 0%, {{bg_end}} 100%);
+    padding: 5% 6% 6%;
   }
   .device-area {
-    padding-top: 5%;
     display: flex;
     justify-content: center;
+    align-items: flex-start;
+    width: 100%;
   }
   .device-area img {
-    width: 72%;
+    width: 78%;
     height: auto;
     object-fit: contain;
+    transform: translateY(-2%);
   }
   .text-area {
-    margin-top: auto;
-    margin-bottom: 6%;
     text-align: center;
-    padding: 0 8%;
+    padding: 0 6%;
+    max-width: 86%;
   }
   h1 {
     font-size: 110px;
@@ -235,20 +295,21 @@ All templates use viewport-sized layouts. Koubou sets the viewport to the exact 
     background: linear-gradient(135deg, {{bg_start}} 0%, {{bg_mid}} 50%, {{bg_end}} 100%);
   }
   .device-area {
-    width: 55%;
+    width: 58%;
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: 5%;
+    padding: 4% 2% 4% 5%;
   }
   .device-area img {
-    width: 90%;
+    width: 96%;
     height: auto;
     object-fit: contain;
+    transform: rotate(-7deg);
   }
   .text-area {
-    width: 45%;
-    padding-right: 6%;
+    width: 42%;
+    padding-right: 7%;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -396,3 +457,5 @@ These are starting points. For each project, adapt:
 - **Device image width**: Adjust between 65-85% based on how much screen real estate the device needs
 - **Spacing**: Adjust padding percentages based on text/device balance
 - **Additional elements**: Add app icons, floating UI elements, or badges as extra `<img>` tags using additional asset variables
+- **Composition**: If the template still feels generic after first render, change layout, scale, or posture instead of only tweaking colors
+- **Quality gate**: Do not ship the first successful render; compare it against the rejection checklist and iterate until it feels like App Store marketing

--- a/skills/koubou/setup.md
+++ b/skills/koubou/setup.md
@@ -1,68 +1,116 @@
 # Setup Guide
 
-## Installation
+## Golden rule
 
-### Quick install (recommended)
+If `kou --version` works, koubou is already installed. Stop there.
 
-```bash
-pip3 install koubou
-kou setup-html
-```
+Do not run `pip`, `pip3`, or `playwright install` on a working installation just because this skill is being used.
 
-If Google Chrome is already installed, `kou setup-html` will usually confirm that HTML rendering is already ready without downloading Chromium.
+## Preferred setup flow
 
-### Verify installation
+### 1. Check whether koubou already works
 
 ```bash
 kou --version
 kou list-frames "iPhone 16"
-kou setup-html --help
 ```
 
-### Alternative: install from source
+If both commands work:
+- treat the installation as healthy
+- do not reinstall koubou
+- do not run low-level Playwright commands
+
+### 2. Always prepare the HTML runtime for this skill
+
+This skill is specifically for HTML template rendering, so run:
+
+```bash
+kou setup-html
+```
+
+Run it after `kou --version` succeeds. Treat it as safe and idempotent.
+
+Do not replace this with low-level Playwright commands.
+
+### 3. Install koubou only if `kou` is missing
+
+Use installation commands only when `kou --version` fails.
+
+#### macOS with Homebrew
+
+```bash
+brew install bitomule/tap/koubou
+```
+
+#### PyPI install
+
+```bash
+pip3 install koubou
+```
+
+#### Install from source
 
 ```bash
 git clone https://github.com/bitomule/Koubou.git /tmp/koubou
 cd /tmp/koubou
 pip3 install .
-kou setup-html
 ```
 
 ## Troubleshooting
 
-### `kou setup-html` fails
+### `kou` works, but HTML rendering is not ready
 
-Try installing system Chrome instead — koubou tries system Chrome first before falling back to Playwright's bundled Chromium.
+Use the product command first:
 
 ```bash
-# macOS
-brew install --cask google-chrome
+kou setup-html
 ```
 
-### `ModuleNotFoundError: No module named 'playwright'`
+Koubou handles browser/runtime setup through this command. Do not bypass it.
 
-Your koubou installation predates the built-in HTML runtime dependency. Update koubou, then run setup again:
+### `kou` is missing
+
+Install koubou first:
 
 ```bash
-pip3 install --upgrade koubou
-kou setup-html
+brew install bitomule/tap/koubou
+```
+
+Or:
+
+```bash
+pip3 install koubou
+```
+
+Then verify with:
+
+```bash
+kou --version
 ```
 
 ### `No browser available for HTML rendering`
 
-Neither system Chrome nor Playwright Chromium is available:
+Preferred path:
 
 ```bash
 kou setup-html
-# or install Chrome manually
 ```
+
+If this fails, surface the exact error to the user and stop. Do not jump to manual Playwright commands on your own.
+
+### PEP 668 or externally-managed Python errors
+
+Do not try to force `pip` into a system-managed Python if `kou` already works.
+
+If `kou --version` succeeds:
+- treat the installation as valid
+- use `kou setup-html` for HTML runtime setup
+
+If `kou` is not installed, prefer a project virtual environment instead of mutating system Python.
 
 ### Permission errors on macOS
 
-```bash
-pip3 install --user koubou
-kou setup-html
-```
+Prefer using the existing `kou` installation. If installation is truly required, use a project virtual environment.
 
 ### Virtual environment
 


### PR DESCRIPTION
## Summary
- harden the bundled koubou skill around HTML setup, narrative planning, and visual rejection rules
- refresh the Undolly example with stronger copy and more varied HTML templates
- keep the example workflow aligned with the skill guidance and current HTML setup flow

## Validation
- make check
- /Users/davidcollado/Projects/koubou/.venv/bin/kou setup-html
- /Users/davidcollado/Projects/koubou/.venv/bin/kou generate config.yaml --verbose (from examples/undolly)
