### PR TITLE
Fix 4 missing f-string prefixes in device frame renderer that broke all debug logging

### DIFF
--- a/src/koubou/renderers/device_frame.py
+++ b/src/koubou/renderers/device_frame.py
@@ -79,7 +79,7 @@ class DeviceFrameRenderer:
             else:
                 # Fall back to simple overlay approach
                 logger.warning(
-                    "No metadata found for {device_frame_name}, using simple overlay"
+                    f"No metadata found for {device_frame_name}, using simple overlay"
                 )
                 result = self._compose_simple_overlay(canvas, frame_image)
 
@@ -142,7 +142,7 @@ class DeviceFrameRenderer:
                 current = current.get(variant)
                 if not current:
                     logger.warning(
-                        "Variant '{variant}' not found under {device_type} {model_key}"
+                        f"Variant '{variant}' not found under {device_type} {model_key}"
                     )
                     return None
 
@@ -193,7 +193,7 @@ class DeviceFrameRenderer:
             logger.info(f"📐 Using legacy format: x={screen_x}, y={screen_y}")
 
         logger.info(
-            "📐 Screen area: {screen_x}, {screen_y}, {screen_width}×{screen_height}"
+            f"📐 Screen area: {screen_x}, {screen_y}, {screen_width}×{screen_height}"
         )
 
         # Scale source image to fit the screen area properly
@@ -441,7 +441,7 @@ class DeviceFrameRenderer:
             )
 
             logger.info(
-                "📱 Generated screen mask for {frame_name} using boundary detection"
+                f"📱 Generated screen mask for {frame_name} using boundary detection"
             )
             return screen_mask
 


### PR DESCRIPTION
## Summary

- Fix 4 missing `f`-string prefixes in `src/koubou/renderers/device_frame.py` that caused all device frame debug/warning log messages to show literal `{variable_name}` text instead of actual values
- This made it impossible to debug device frame metadata lookup failures, a common scenario with complex frame names like `"iPhone 15 Pro - Natural Titanium - Portrait"`

### Fixed lines

| Line | Logger level | Variables affected |
|------|-------------|-------------------|
| 82 | `warning` | `device_frame_name` |
| 145 | `warning` | `variant`, `device_type`, `model_key` |
| 196 | `info` | `screen_x`, `screen_y`, `screen_width`, `screen_height` |
| 444 | `info` | `frame_name` |

### Before

```
WARNING: No metadata found for {device_frame_name}, using simple overlay
WARNING: Variant '{variant}' not found under {device_type} {model_key}
```

### After

```
WARNING: No metadata found for iPhone 15 Pro - Natural Titanium - Portrait, using simple overlay
WARNING: Variant 'Pro' not found under iPhone 15 Pro
```

## Test plan

- [x] All 389 existing tests pass
- [ ] Run `kou generate` with a config that uses device frames and verify log output shows actual frame names
- [ ] Run `kou generate` with an intentionally misspelled frame name and verify the warning message includes the actual name