### PR TITLE
Fix pixel position parsing for content items (issue #19)

### DIFF
--- a/src/koubou/generator.py
+++ b/src/koubou/generator.py
@@ -649,14 +649,19 @@ class ScreenshotGenerator:
 
         return TempConfig(base_config, img_config)
 
-    def _convert_percentage_to_pixels(self, percentage_str: str, dimension: int) -> int:
-        """Convert percentage string to pixel position."""
-        if percentage_str.endswith("%"):
-            percentage = float(percentage_str[:-1])
+    def _parse_position_value(self, value: str, dimension: int) -> int:
+        """Parse percentage, pixel-suffixed, or raw numeric position value."""
+        normalized = value.strip().lower()
+        if normalized.endswith("%"):
+            percentage = float(normalized[:-1])
             return int(dimension * percentage / 100.0)
-        else:
-            # If not a percentage, assume it's already pixels
-            return int(percentage_str)
+        if normalized.endswith("px"):
+            normalized = normalized[:-2].strip()
+        return int(float(normalized))
+
+    def _convert_percentage_to_pixels(self, percentage_str: str, dimension: int) -> int:
+        """Convert percentage or pixel value string to pixel position."""
+        return self._parse_position_value(percentage_str, dimension)
 
     def _apply_device_frame_overlay(
         self, canvas: Image.Image, device_frame_name: str
@@ -1407,16 +1412,7 @@ class ScreenshotGenerator:
         """Convert percentage or pixel position to absolute pixels."""
         canvas_width, canvas_height = canvas_size
 
-        # Convert X position
-        if position[0].endswith("%"):
-            x = int(canvas_width * float(position[0][:-1]) / 100)
-        else:
-            x = int(float(position[0]))
-
-        # Convert Y position
-        if position[1].endswith("%"):
-            y = int(canvas_height * float(position[1][:-1]) / 100)
-        else:
-            y = int(float(position[1]))
+        x = self._parse_position_value(position[0], canvas_width)
+        y = self._parse_position_value(position[1], canvas_height)
 
         return (x, y)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -487,6 +487,55 @@ class TestScreenshotGenerator:
             0,
         )
 
+    def test_convert_position_supports_pixel_suffix(self):
+        """Position parser should support values with px suffix."""
+        assert self.generator._convert_position(["100px", "50px"], (1000, 500)) == (
+            100,
+            50,
+        )
+
+    def test_convert_position_supports_mixed_percent_and_pixels(self):
+        """Position parser should support mixed percent and pixel values."""
+        assert self.generator._convert_position(["50%", "120px"], (1000, 800)) == (
+            500,
+            120,
+        )
+
+    def test_project_generation_accepts_px_positions_for_text_and_image(self):
+        """Regression: project generation should accept px position values."""
+        from koubou.config import ContentItem, ProjectInfo, ScreenshotDefinition
+
+        project_config = ProjectConfig(
+            project=ProjectInfo(
+                name="PX Position Regression",
+                output_dir=str(self.temp_dir / "project_px_output"),
+                device="iPhone 15 Pro Portrait",
+            ),
+            screenshots={
+                "pixel_positions": ScreenshotDefinition(
+                    content=[
+                        ContentItem(
+                            type="image",
+                            asset=str(self.source_image_path),
+                            position=("100px", "200px"),
+                        ),
+                        ContentItem(
+                            type="text",
+                            content="Top Left",
+                            position=("120px", "80px"),
+                            alignment="left",
+                        ),
+                    ],
+                    frame=False,
+                )
+            },
+        )
+
+        results = self.generator.generate_project(project_config)
+
+        assert len(results) == 1
+        assert results[0].exists()
+
 
 class TestResolveLocalizedAsset:
     """Tests for resolve_localized_asset() function."""


### PR DESCRIPTION
## Summary
- fix position parsing in generator to accept `%`, `px`, and raw numeric values
- apply the same parser to both text and image conversion paths
- add regression tests for pixel and mixed positions
- add project-generation regression test covering text + image with px values

## Validation
- `.venv/bin/pytest tests/test_generator.py -v`

Fixes #19