### PR TITLE
Fix horizontal alignment semantics for project text and image content

### DIFF
--- a/docs/yaml-api.md
+++ b/docs/yaml-api.md
@@ -226,6 +226,8 @@ Content items define the visual elements within each screenshot.
   weight: string?            # "normal" or "bold" (default: "normal")
   font_family: string?       # Font family name (default: "Arial")
   alignment: string?         # "left", "center", "right" (default: "center")
+                             # Also defines how position.x is interpreted:
+                             # left=edge, center=midpoint, right=edge
 
   # Stroke Options (optional):
   stroke_width: int?         # Stroke width in pixels
@@ -286,6 +288,9 @@ When `min_size`, `max_width`, and `max_height` are all set, Koubou automatically
 - type: "image"
   asset: string              # Path to image file (required)
   position: [string, string] # Position as ["50%", "60%"] or ["200px", "300px"] (required)
+  alignment: string?         # "left", "center", "right" (default: "center")
+                             # Defines how position.x is interpreted:
+                             # left=edge, center=midpoint, right=edge
   scale: float?              # Scale factor (default: 1.0)
   frame: bool?               # Apply device frame around image (default: false)
 ```

--- a/src/koubou/config.py
+++ b/src/koubou/config.py
@@ -352,7 +352,7 @@ class ContentItem(BaseModel):
 
     weight: Optional[str] = Field(default="normal", description="Font weight")
     font_family: Optional[str] = Field(default="Arial", description="Font family name")
-    alignment: Optional[str] = Field(
+    alignment: Optional[Literal["left", "center", "right"]] = Field(
         default="center", description="Text alignment (left, center, right)"
     )
 

--- a/src/koubou/generator.py
+++ b/src/koubou/generator.py
@@ -638,17 +638,17 @@ class ScreenshotGenerator:
         position = config.image_position or ["50%", "50%"]
         x_percent, y_percent = position
 
-        # Convert percentage strings to pixel positions (asset center positioning)
-        center_x = self._convert_percentage_to_pixels(x_percent, canvas_width)
+        # Resolve requested position, then apply horizontal alignment semantics
+        requested_x = self._convert_percentage_to_pixels(x_percent, canvas_width)
         center_y = self._convert_percentage_to_pixels(y_percent, canvas_height)
+        alignment = getattr(config, "image_alignment", "center") or "center"
 
-        # Calculate top-left position (center the asset at the % position)
-        x = center_x - scaled_width // 2
+        x = self._calculate_horizontal_position(requested_x, scaled_width, alignment)
         y = center_y - scaled_height // 2
 
         logger.info(
-            f"📐 Positioning asset: center at {position} → "
-            f"({center_x}, {center_y}), top-left at ({x}, {y})"
+            f"📐 Positioning asset: requested={position}, alignment={alignment} → "
+            f"top-left at ({x}, {y})"
         )
 
         # Create positioned image
@@ -669,6 +669,7 @@ class ScreenshotGenerator:
                 self.device_frame = base.device_frame
                 self.output_size = base.output_size
                 self.image_position = img["position"]
+                self.image_alignment = img.get("alignment", "center")
                 self.image_scale = img["scale"]
                 self.image_frame = img["frame"]
                 self.image_rotation = img.get("rotation", 0)
@@ -877,8 +878,9 @@ class ScreenshotGenerator:
 
             # Step 4: Calculate positioning
             position = config.image_position or ["50%", "50%"]
-            center_x = self._convert_percentage_to_pixels(position[0], canvas.width)
+            requested_x = self._convert_percentage_to_pixels(position[0], canvas.width)
             center_y = self._convert_percentage_to_pixels(position[1], canvas.height)
+            alignment = getattr(config, "image_alignment", "center") or "center"
 
             # Source position (centered within frame's screen area)
             scaled_screen_x = int(screen_x * asset_scale)
@@ -931,14 +933,16 @@ class ScreenshotGenerator:
                     f"to {asset_scale * canvas_fit_scale:.6f} to avoid clipping"
                 )
 
-            # Step 7: Place framed asset on canvas centered at requested position
+            # Step 7: Place framed asset on canvas using horizontal alignment
             framed_width, framed_height = framed_asset.size
-            frame_x = center_x - framed_width // 2
+            frame_x = self._calculate_horizontal_position(
+                requested_x, framed_width, alignment
+            )
             frame_y = center_y - framed_height // 2
 
             logger.info(
-                f"📱 Positioning framed asset: center at ({center_x}, {center_y}), "
-                f"top-left at ({frame_x}, {frame_y})"
+                f"📱 Positioning framed asset: requested={position}, "
+                f"alignment={alignment}, top-left at ({frame_x}, {frame_y})"
             )
 
             result = Image.new("RGBA", canvas.size, (255, 255, 255, 0))
@@ -1221,6 +1225,7 @@ class ScreenshotGenerator:
 
                 image_scale = item.scale or 1.0
                 image_position = item.position or ["50%", "50%"]  # Default to center
+                image_alignment = getattr(item, "alignment", "center") or "center"
 
                 # Store image configuration including frame and rotation settings
                 image_rotation = getattr(item, "rotation", 0) or 0
@@ -1228,6 +1233,7 @@ class ScreenshotGenerator:
                     "path": source_image_path,
                     "scale": image_scale,
                     "position": image_position,
+                    "alignment": image_alignment,
                     "frame": getattr(item, "frame", False),  # Capture frame setting
                     "rotation": image_rotation,  # Capture rotation setting
                 }
@@ -1235,6 +1241,7 @@ class ScreenshotGenerator:
                 logger.info(
                     f"📏 Image: scale={image_scale * 100:.0f}%, "
                     f"position={image_position}, "
+                    f"alignment={image_alignment}, "
                     f"frame={getattr(item, 'frame', False)}, rotation={image_rotation}°"
                 )
                 # Continue processing more images instead of breaking
@@ -1348,6 +1355,7 @@ class ScreenshotGenerator:
             if item.type == "text":
                 # Convert to TextOverlay
                 if item.content:
+                    alignment = getattr(item, "alignment", "center") or "center"
                     position = self._convert_position(
                         item.position, (canvas_width, canvas_height)
                     )
@@ -1360,9 +1368,8 @@ class ScreenshotGenerator:
                         color=item.color,  # Don't default to black if gradient
                         # is provided
                         gradient=item.gradient,  # Pass gradient configuration
-                        alignment=getattr(item, "alignment", "center") or "center",
-                        anchor="center",  # Use center anchor for
-                        # percentage-based positioning
+                        alignment=alignment,
+                        anchor=self._text_anchor_from_alignment(alignment),
                         max_width=item.max_width,
                         max_lines=item.max_lines,
                         min_font_size=item.min_size,
@@ -1436,6 +1443,31 @@ class ScreenshotGenerator:
         config._zoom_configs = zoom_configs  # type: ignore[attr-defined]
 
         return config
+
+    @staticmethod
+    def _text_anchor_from_alignment(alignment: str) -> str:
+        """Map project text alignment to the corresponding horizontal anchor.
+
+        Project YAML exposes only left/center/right alignment. We keep the
+        existing vertical centering behavior, but make the x-position reference
+        match the chosen alignment so pixel offsets remain stable.
+        """
+        if alignment == "left":
+            return "center-left"
+        if alignment == "right":
+            return "center-right"
+        return "center"
+
+    @staticmethod
+    def _calculate_horizontal_position(
+        requested_x: int, content_width: int, alignment: str
+    ) -> int:
+        """Resolve top-left x from the requested x and horizontal alignment."""
+        if alignment == "left":
+            return requested_x
+        if alignment == "right":
+            return requested_x - content_width
+        return requested_x - content_width // 2
 
     def _convert_position(
         self, position: list[str], canvas_size: tuple[int, int]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -171,6 +171,29 @@ class TestContentItemFontFamily:
         assert item.font_family is None
 
 
+class TestContentItemAlignment:
+    """Tests for ContentItem alignment validation."""
+
+    def test_alignment_accepts_supported_values(self):
+        for alignment in ["left", "center", "right"]:
+            item = ContentItem(
+                type="image",
+                asset="image.png",
+                position=("50%", "50%"),
+                alignment=alignment,
+            )
+            assert item.alignment == alignment
+
+    def test_alignment_rejects_invalid_value(self):
+        with pytest.raises(ValidationError, match="Input should be 'left', 'center' or 'right'"):
+            ContentItem(
+                type="image",
+                asset="image.png",
+                position=("50%", "50%"),
+                alignment="centre",
+            )
+
+
 class TestContentItemHighlight:
     """Tests for ContentItem with type='highlight'."""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,7 +185,9 @@ class TestContentItemAlignment:
             assert item.alignment == alignment
 
     def test_alignment_rejects_invalid_value(self):
-        with pytest.raises(ValidationError, match="Input should be 'left', 'center' or 'right'"):
+        with pytest.raises(
+            ValidationError, match="Input should be 'left', 'center' or 'right'"
+        ):
             ContentItem(
                 type="image",
                 asset="image.png",

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -536,6 +536,91 @@ class TestScreenshotGenerator:
         assert len(results) == 1
         assert results[0].exists()
 
+    def test_project_text_alignment_controls_horizontal_anchor(self):
+        """Project text alignment should determine horizontal anchor semantics."""
+        from koubou.config import ContentItem, ScreenshotDefinition
+
+        expected_anchors = {
+            "left": "center-left",
+            "center": "center",
+            "right": "center-right",
+        }
+
+        for alignment, expected_anchor in expected_anchors.items():
+            screenshot_def = ScreenshotDefinition(
+                content=[
+                    ContentItem(
+                        type="image",
+                        asset=str(self.source_image_path),
+                        position=("50%", "50%"),
+                    ),
+                    ContentItem(
+                        type="text",
+                        content="Aligned text",
+                        position=("120px", "80px"),
+                        alignment=alignment,
+                    ),
+                ],
+                frame=False,
+            )
+
+            config = self.generator._convert_to_screenshot_config(
+                screenshot_def=screenshot_def,
+                device_frame=None,
+                default_background=None,
+                output_dir=str(self.temp_dir / "project_alignment_output"),
+                output_size=(1000, 800),
+            )
+
+            assert config is not None
+            assert len(config.text_overlays) == 1
+            assert config.text_overlays[0].alignment == alignment
+            assert config.text_overlays[0].anchor == expected_anchor
+            assert config.text_overlays[0].position == (120, 80)
+
+    def test_position_source_image_respects_left_alignment(self):
+        """Image alignment should control horizontal placement for project assets."""
+        canvas = Image.new("RGBA", (400, 300), (255, 255, 255, 0))
+        source_image = Image.open(self.source_image_path)
+
+        class TempConfig:
+            image_scale = 1.0
+            image_position = ["120px", "50%"]
+            image_alignment = "left"
+            image_rotation = 0
+
+        result = self.generator._position_source_image(source_image, canvas, TempConfig())
+
+        assert result.getbbox() == (120, 0, 320, 300)
+
+    def test_apply_asset_frame_respects_left_alignment(self):
+        """Framed images should use left alignment for horizontal placement."""
+        frame = Image.new("RGBA", (200, 400), (128, 128, 128, 255))
+        screen_x, screen_y = 20, 40
+        screen_width, screen_height = 160, 320
+
+        for y in range(screen_y, screen_y + screen_height):
+            for x in range(screen_x, screen_x + screen_width):
+                frame.putpixel((x, y), (128, 128, 128, 0))
+
+        frame_path = self.frame_dir / "Left Align Frame.png"
+        frame.save(frame_path)
+
+        canvas = Image.new("RGBA", (800, 1200), (255, 255, 255, 0))
+
+        class TempConfig:
+            device_frame = "Left Align Frame"
+            image_scale = 1.0
+            image_position = ["120px", "50%"]
+            image_alignment = "left"
+            image_rotation = 0
+
+        result = self.generator._apply_asset_frame(
+            Image.open(self.source_image_path), canvas, TempConfig()
+        )
+
+        assert result.getbbox() == (120, 400, 320, 800)
+
 
 class TestResolveLocalizedAsset:
     """Tests for resolve_localized_asset() function."""

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -589,7 +589,9 @@ class TestScreenshotGenerator:
             image_alignment = "left"
             image_rotation = 0
 
-        result = self.generator._position_source_image(source_image, canvas, TempConfig())
+        result = self.generator._position_source_image(
+            source_image, canvas, TempConfig()
+        )
 
         assert result.getbbox() == (120, 0, 320, 300)
 


### PR DESCRIPTION
I worked with Codex to fix the issues I described in #21, as an offshoot of the fixes in #19.

- Make project text `alignment` control the horizontal anchor so pixel x positions stay stable
- Make project image `alignment` use the same left/center/right horizontal semantics for framed and unframed assets
- Document the updated x-position behavior and add regression coverage for project text and images
- Added tests to ensure the layout issues don't emerge again.

I verified this on my computer and generated 15 new screenshots using this layout, but please let me know if anything doesn't work or doesn't match the structure or goals you have for this project @bitomule.