### PR TITLE
Fix localized template assets in HTML screenshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ format:
 	$(ISORT) src/ tests/
 
 lint:
+	$(BLACK) --check src/ tests/
+	$(ISORT) --check-only --diff src/ tests/
 	$(FLAKE8) src/ tests/
 	$(MYPY) src/
 

--- a/src/koubou/config.py
+++ b/src/koubou/config.py
@@ -8,6 +8,9 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 
+LocalizedAsset = Union[str, Dict[str, str]]
+
+
 def load_appstore_sizes() -> Dict[str, Dict[str, Union[int, str]]]:
     """Load App Store standard sizes from JSON file."""
     sizes_file = Path(__file__).parent / "appstore_sizes.json"
@@ -311,7 +314,7 @@ class ContentItem(BaseModel):
         ..., description="Type of content item"
     )
     content: Optional[str] = Field(default=None, description="Text content")
-    asset: Optional[Union[str, Dict[str, str]]] = Field(
+    asset: Optional[LocalizedAsset] = Field(
         default=None,
         description=(
             "Image asset path. Supports two formats:\n"
@@ -590,8 +593,8 @@ class ContentItem(BaseModel):
     @field_validator("asset")
     @classmethod
     def validate_asset_format(
-        cls, v: Optional[Union[str, Dict[str, str]]]
-    ) -> Optional[Union[str, Dict[str, str]]]:
+        cls, v: Optional[LocalizedAsset]
+    ) -> Optional[LocalizedAsset]:
         """Validate asset field format."""
         if v is None:
             return v
@@ -638,9 +641,12 @@ class ScreenshotDefinition(BaseModel):
         default_factory=dict,
         description="Localizable text variables for {{key}} substitution",
     )
-    assets: Dict[str, str] = Field(
+    assets: Dict[str, LocalizedAsset] = Field(
         default_factory=dict,
-        description="Asset path variables for {{key}} substitution (not localized)",
+        description=(
+            "Asset path variables for {{key}} substitution. Supports strings "
+            "with localized directory conventions and explicit language maps."
+        ),
     )
     frame: Optional[bool] = Field(
         default=None,
@@ -661,6 +667,18 @@ class ScreenshotDefinition(BaseModel):
         if not has_template and not has_content:
             raise ValueError("Must specify either 'template' or 'content'.")
         return self
+
+    @field_validator("assets")
+    @classmethod
+    def validate_assets_format(
+        cls, v: Dict[str, LocalizedAsset]
+    ) -> Dict[str, LocalizedAsset]:
+        """Validate template asset mappings using the same rules as content assets."""
+        for key, asset in v.items():
+            validated = ContentItem.validate_asset_format(asset)
+            if validated in (None, ""):
+                raise ValueError(f"Asset '{key}' must be a non-empty string or mapping")
+        return v
 
 
 class LocalizationConfig(BaseModel):

--- a/src/koubou/config.py
+++ b/src/koubou/config.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
-
 LocalizedAsset = Union[str, Dict[str, str]]
 
 

--- a/src/koubou/generator.py
+++ b/src/koubou/generator.py
@@ -11,7 +11,13 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from PIL import Image
 
-from .config import GradientConfig, ProjectConfig, ScreenshotConfig, TextOverlay
+from .config import (
+    GradientConfig,
+    LocalizedAsset,
+    ProjectConfig,
+    ScreenshotConfig,
+    TextOverlay,
+)
 from .exceptions import ConfigurationError, RenderError
 from .localization import LocalizedContentResolver, XCStringsManager
 from .renderers.background import BackgroundRenderer
@@ -310,19 +316,30 @@ class ScreenshotGenerator:
 
     def _build_assets_map(
         self,
-        asset_variables: Dict[str, str],
+        asset_variables: Dict[str, LocalizedAsset],
         config_dir: Optional[Path],
-    ) -> Dict[str, str]:
-        """Build {relative_name: absolute_path} map for HTML sandbox."""
+        language: str = "en",
+        base_language: str = "en",
+    ) -> Tuple[Dict[str, str], Dict[str, str]]:
+        """Build HTML asset mounts and template variables for the sandbox."""
         assets: Dict[str, str] = {}
+        template_assets: Dict[str, str] = {}
         for key, value in asset_variables.items():
-            if config_dir:
-                candidate = config_dir / value
-            else:
-                candidate = Path(value)
+            resolved = resolve_localized_asset(
+                value, language, base_language, config_dir
+            )
+            if not resolved:
+                continue
+
+            candidate = Path(resolved)
+            if not candidate.is_absolute() and config_dir:
+                candidate = config_dir / candidate
+
             if candidate.exists():
-                assets[value] = str(candidate.resolve())
-        return assets
+                mounted_name = key if Path(key).suffix else f"{key}{candidate.suffix}"
+                assets[mounted_name] = str(candidate.resolve())
+                template_assets[key] = mounted_name
+        return assets, template_assets
 
     def prepare_html_screenshot(
         self,
@@ -331,6 +348,7 @@ class ScreenshotGenerator:
         *,
         device_frame_name: Optional[str] = None,
         language: str = "en",
+        base_language: Optional[str] = None,
         xcstrings_manager: Optional[Any] = None,
         assets_output_dir: Optional[Path] = None,
     ) -> PreparedHtmlScreenshot:
@@ -348,7 +366,13 @@ class ScreenshotGenerator:
             screenshot_def.variables, language, xcstrings_manager
         )
 
-        assets = self._build_assets_map(screenshot_def.assets, config_dir)
+        resolved_base_language = base_language or language
+        assets, resolved_asset_variables = self._build_assets_map(
+            screenshot_def.assets,
+            config_dir,
+            language=language,
+            base_language=resolved_base_language,
+        )
         should_frame = screenshot_def.frame is not False and device_frame_name
         cleanup_paths: List[Path] = []
 
@@ -375,7 +399,7 @@ class ScreenshotGenerator:
                     prepared_assets[rel_path] = abs_path
             assets = prepared_assets
 
-        all_variables = {**resolved_text, **screenshot_def.assets}
+        all_variables = {**resolved_text, **resolved_asset_variables}
         return PreparedHtmlScreenshot(
             template_path=template_path,
             variables=all_variables,
@@ -392,6 +416,7 @@ class ScreenshotGenerator:
         config_dir: Optional[Path],
         device_frame_name: Optional[str] = None,
         language: str = "en",
+        base_language: Optional[str] = None,
         xcstrings_manager: Optional[Any] = None,
     ) -> Path:
         """Generate a screenshot from an HTML template."""
@@ -400,6 +425,7 @@ class ScreenshotGenerator:
             config_dir,
             device_frame_name=device_frame_name,
             language=language,
+            base_language=base_language,
             xcstrings_manager=xcstrings_manager,
         )
 
@@ -1061,6 +1087,11 @@ class ScreenshotGenerator:
                             config_dir=config_dir,
                             device_frame_name=device,
                             language=language,
+                            base_language=(
+                                localization_config.base_language
+                                if localization_config
+                                else None
+                            ),
                             xcstrings_manager=xcm,
                         )
                         all_results.append(output_path)

--- a/src/koubou/live_generator.py
+++ b/src/koubou/live_generator.py
@@ -489,6 +489,11 @@ class LiveScreenshotGenerator:
             self.config_dir,
             device_frame_name=self.current_config.project.device,
             language=language,
+            base_language=(
+                self.current_config.localization.base_language
+                if self.current_config.localization
+                else language
+            ),
             xcstrings_manager=xcstrings_manager,
             assets_output_dir=stage_dir,
         )

--- a/tests/test_html_renderer.py
+++ b/tests/test_html_renderer.py
@@ -354,3 +354,99 @@ class TestAssetsFieldValidation:
             assets={"screen": "assets/screen.png"},
         )
         assert defn.variables == {}
+
+    def test_assets_support_localized_mapping(self):
+        defn = ScreenshotDefinition(
+            template="hero.html",
+            assets={
+                "app_screenshot": {
+                    "en": "assets/en/screen.png",
+                    "es": "assets/es/screen.png",
+                    "default": "assets/default.png",
+                }
+            },
+        )
+        assert defn.assets["app_screenshot"]["es"] == "assets/es/screen.png"
+
+
+class TestHtmlTemplateAssetLocalization:
+    """Test localized asset resolution for template-based screenshots."""
+
+    def _make_generator(self, temp_dir):
+        from koubou.generator import ScreenshotGenerator
+
+        frames_dir = temp_dir / "frames"
+        frames_dir.mkdir()
+        (frames_dir / "Frames.json").write_text("{}", encoding="utf-8")
+        (frames_dir / "Sizes.json").write_text("{}", encoding="utf-8")
+        return ScreenshotGenerator(frame_directory=str(frames_dir))
+
+    def test_prepare_html_screenshot_localizes_string_assets(self, temp_dir):
+        generator = self._make_generator(temp_dir)
+
+        template = temp_dir / "hero.html"
+        template.write_text(
+            '<html><body><img src="{{app_screenshot}}"></body></html>',
+            encoding="utf-8",
+        )
+
+        raw_dir = temp_dir / "raw"
+        (raw_dir / "en").mkdir(parents=True)
+        (raw_dir / "es").mkdir(parents=True)
+        Image.new("RGB", (20, 20), (255, 0, 0)).save(raw_dir / "en" / "hello.png")
+        Image.new("RGB", (20, 20), (0, 255, 0)).save(raw_dir / "es" / "hello.png")
+
+        screenshot = ScreenshotDefinition(
+            template=str(template),
+            assets={"app_screenshot": "raw/hello.png"},
+            frame=False,
+        )
+
+        prepared = generator.prepare_html_screenshot(
+            screenshot,
+            temp_dir,
+            language="es",
+            base_language="en",
+        )
+
+        assert prepared.variables["app_screenshot"] == "app_screenshot.png"
+        assert prepared.assets["app_screenshot.png"] == str(
+            (raw_dir / "es" / "hello.png").resolve()
+        )
+
+    def test_prepare_html_screenshot_localizes_dict_assets(self, temp_dir):
+        generator = self._make_generator(temp_dir)
+
+        template = temp_dir / "hero.html"
+        template.write_text(
+            '<html><body><img src="{{app_screenshot}}"></body></html>',
+            encoding="utf-8",
+        )
+
+        raw_dir = temp_dir / "raw"
+        raw_dir.mkdir()
+        Image.new("RGB", (20, 20), (255, 0, 0)).save(raw_dir / "fallback.png")
+        Image.new("RGB", (20, 20), (0, 255, 0)).save(raw_dir / "es.png")
+
+        screenshot = ScreenshotDefinition(
+            template=str(template),
+            assets={
+                "app_screenshot": {
+                    "es": "raw/es.png",
+                    "default": "raw/fallback.png",
+                }
+            },
+            frame=False,
+        )
+
+        prepared = generator.prepare_html_screenshot(
+            screenshot,
+            temp_dir,
+            language="fr",
+            base_language="en",
+        )
+
+        assert prepared.variables["app_screenshot"] == "app_screenshot.png"
+        assert prepared.assets["app_screenshot.png"] == str(
+            (raw_dir / "fallback.png").resolve()
+        )


### PR DESCRIPTION
## Summary
- resolve template-based screenshot assets with the same localized asset logic used by content mode
- keep HTML asset placeholders stable by mounting resolved files under the asset key
- allow localized asset mappings in ScreenshotDefinition.assets and cover the regression with tests

## Testing
- .venv/bin/pytest tests/test_html_renderer.py tests/test_generator.py tests/test_live_generator.py -q