### PR TITLE
Add compact layout JSON for HTML screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,40 @@ Koubou can export a compact sidecar layout manifest for every HTML screenshot. A
 - `data-kou-id` is required for an element to appear in the manifest
 - `data-kou-role` is optional contextual metadata
 - Koubou writes `<screenshot_id>.layout.json` next to the PNG
+- `kou generate config.yaml --output json` also returns `layout_path` for each generated HTML screenshot
 - The JSON contains only normalized `x`, `y`, `width`, `height` plus optional `role`, `text`, `src`, `zIndex`, and mathematical `overlaps`
+- All geometry values are ratios from `0..1` relative to the final canvas
+- If a template has no `data-kou-id` annotations, the sidecar is still written with empty `elements` and `overlaps`
+
+Example:
+
+```json
+{
+  "version": 1,
+  "elements": [
+    {
+      "id": "headline",
+      "role": "headline",
+      "x": 0.08,
+      "y": 0.07,
+      "width": 0.62,
+      "height": 0.18
+    },
+    {
+      "id": "device",
+      "role": "device",
+      "src": "home.png",
+      "x": 0.19,
+      "y": 0.31,
+      "width": 0.61,
+      "height": 0.58
+    }
+  ],
+  "overlaps": []
+}
+```
+
+Use this file for objective layout facts only: element positions, occupied space, and real overlaps. Koubou does not interpret whether something is too small, too large, or aesthetically correct.
 
 ## 🔄 Live Editing
 
@@ -398,6 +431,8 @@ kou generate config.yaml --setup-html
 # Enable verbose logging
 kou generate config.yaml --verbose
 ```
+
+For HTML screenshots, `--output json` includes `layout_path` alongside the PNG path so tooling can open the measured layout sidecar directly.
 
 #### HTML Setup
 ```bash

--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ screenshots:
 - `kou live config.yaml --setup-html` does the same before starting live mode
 - `kou inspect-frame "<device>" --output-size <size> --output json` exposes frame and screen geometry for layout decisions
 
+### Compact Layout JSON
+
+Koubou can export a compact sidecar layout manifest for every HTML screenshot. Annotate only the elements you want to expose to the LLM:
+
+```html
+<div class="copy">
+  <h1 data-kou-id="headline" data-kou-role="headline">{{headline}}</h1>
+  <p data-kou-id="subtitle" data-kou-role="subheadline">{{subtitle}}</p>
+</div>
+<img class="device" data-kou-id="device" data-kou-role="device" src="{{screen}}" alt="">
+```
+
+- `data-kou-id` is required for an element to appear in the manifest
+- `data-kou-role` is optional contextual metadata
+- Koubou writes `<screenshot_id>.layout.json` next to the PNG
+- The JSON contains only normalized `x`, `y`, `width`, `height` plus optional `role`, `text`, `src`, `zIndex`, and mathematical `overlaps`
+
 ## 🔄 Live Editing
 
 Real-time screenshot regeneration when your YAML configuration or assets change.

--- a/docs/yaml-api.md
+++ b/docs/yaml-api.md
@@ -208,6 +208,13 @@ HTML screenshots can emit a compact sidecar layout manifest for LLM-friendly ins
 <img data-kou-id="device" data-kou-role="device" src="{{screen}}" alt="">
 ```
 
+Generation flow:
+
+1. Annotate only the HTML elements you want measured
+2. Run `kou generate config.yaml --output json`
+3. Read `layout_path` from the command result
+4. Open the referenced `<screenshot_id>.layout.json`
+
 The generated JSON stores only normalized geometry and mathematical overlaps:
 
 ```json
@@ -223,6 +230,48 @@ The generated JSON stores only normalized geometry and mathematical overlaps:
       "height": 0.18
     }
   ],
+  "overlaps": []
+}
+```
+
+Contract:
+
+- Root keys:
+  - `version`
+  - `elements`
+  - `overlaps`
+- `elements[]` keys:
+  - `id`
+  - `x`
+  - `y`
+  - `width`
+  - `height`
+  - optional `role`
+  - optional `text`
+  - optional `src`
+  - optional `zIndex`
+- `overlaps[]` keys:
+  - `first`
+  - `second`
+  - `x`
+  - `y`
+  - `width`
+  - `height`
+
+Rules:
+
+- All geometry values are ratios from `0..1` relative to the final output canvas
+- No pixel geometry is stored in the sidecar
+- Only annotated elements appear in `elements`
+- `overlaps` includes only mathematical box intersections between exported elements
+- Koubou does not classify whether a layout is good or bad; it only measures
+
+If no elements are annotated, Koubou still writes the sidecar in this form:
+
+```json
+{
+  "version": 1,
+  "elements": [],
   "overlaps": []
 }
 ```

--- a/docs/yaml-api.md
+++ b/docs/yaml-api.md
@@ -198,6 +198,35 @@ screenshots:
         position: ["50%", "15%"]
 ```
 
+### HTML Template Layout JSON
+
+HTML screenshots can emit a compact sidecar layout manifest for LLM-friendly inspection. Add `data-kou-id` to any template element you want included in `<screenshot_id>.layout.json`, and optionally add `data-kou-role` for lightweight context.
+
+```html
+<h1 data-kou-id="headline" data-kou-role="headline">{{headline}}</h1>
+<p data-kou-id="subtitle" data-kou-role="subheadline">{{subtitle}}</p>
+<img data-kou-id="device" data-kou-role="device" src="{{screen}}" alt="">
+```
+
+The generated JSON stores only normalized geometry and mathematical overlaps:
+
+```json
+{
+  "version": 1,
+  "elements": [
+    {
+      "id": "headline",
+      "role": "headline",
+      "x": 0.08,
+      "y": 0.07,
+      "width": 0.62,
+      "height": 0.18
+    }
+  ],
+  "overlaps": []
+}
+```
+
 ---
 
 ## Content Items

--- a/examples/undolly/templates/feature_top.html
+++ b/examples/undolly/templates/feature_top.html
@@ -69,11 +69,11 @@
 </head>
 <body>
   <div class="text-area">
-    <h1>{{headline_line_1}}<br><span>{{headline_accent}}</span><br>{{headline_line_3}}</h1>
-    <p>{{subtitle_line_1}}<br>{{subtitle_line_2}}</p>
+    <h1 data-kou-id="headline" data-kou-role="headline">{{headline_line_1}}<br><span>{{headline_accent}}</span><br>{{headline_line_3}}</h1>
+    <p data-kou-id="subtitle" data-kou-role="subheadline">{{subtitle_line_1}}<br>{{subtitle_line_2}}</p>
   </div>
   <div class="device-area">
-    <img src="{{app_screenshot}}">
+    <img data-kou-id="device" data-kou-role="device" src="{{app_screenshot}}">
   </div>
 </body>
 </html>

--- a/examples/undolly/templates/hero.html
+++ b/examples/undolly/templates/hero.html
@@ -66,11 +66,11 @@
 </head>
 <body>
   <div class="text-area">
-    <h1><span>{{headline_accent}}</span> {{headline_rest}}<br>{{headline_tail}}</h1>
-    <p>{{subtitle}}</p>
+    <h1 data-kou-id="headline" data-kou-role="headline"><span>{{headline_accent}}</span> {{headline_rest}}<br>{{headline_tail}}</h1>
+    <p data-kou-id="subtitle" data-kou-role="subheadline">{{subtitle}}</p>
   </div>
   <div class="device-area">
-    <img src="{{app_screenshot}}">
+    <img data-kou-id="device" data-kou-role="device" src="{{app_screenshot}}">
   </div>
 </body>
 </html>

--- a/examples/undolly/templates/side_feature.html
+++ b/examples/undolly/templates/side_feature.html
@@ -69,11 +69,11 @@
 </head>
 <body>
   <div class="text-area">
-    <h1>{{headline_prefix}} <span>{{headline_accent}}</span> {{headline_suffix}}<br>{{headline_tail}}</h1>
-    <p>{{subtitle}}</p>
+    <h1 data-kou-id="headline" data-kou-role="headline">{{headline_prefix}} <span>{{headline_accent}}</span> {{headline_suffix}}<br>{{headline_tail}}</h1>
+    <p data-kou-id="subtitle" data-kou-role="subheadline">{{subtitle}}</p>
   </div>
   <div class="device-area">
-    <img src="{{app_screenshot}}">
+    <img data-kou-id="device" data-kou-role="device" src="{{app_screenshot}}">
   </div>
 </body>
 </html>

--- a/skills/koubou/SKILL.md
+++ b/skills/koubou/SKILL.md
@@ -40,6 +40,8 @@ If breaking a default produces a better screenshot set, break it deliberately an
 Reference files (read as needed, not upfront):
 - `setup.md` — Installation and HTML runtime setup
 - `design-guide.md` — Design principles, copywriting rules, CSS rules, HTML template examples
+- `style-intake.md` — How to inspect the app's real visual language before asking questions
+- `style-interview.md` — Short, high-signal style questions and conversation patterns
 - `yaml-reference.md` — YAML config format, localization, assets, devices, sizes
 - `capabilities-reference.md` — Full koubou capabilities (content mode, highlights, zoom, gradients)
 
@@ -68,43 +70,124 @@ For HTML rendering support:
 
 Only inform the user if setup fails. Never mutate a working installation.
 
-## Phase 2: Gather Information
+## Phase 2: Read The App, Then Ask
 
-Collect what you need through natural conversation. Do NOT dump all questions at once.
+Do not begin with a generic style questionnaire. Inspect the app's real visual language first, then ask only what is still missing or ambiguous.
 
-### Required (ask in order, naturally)
+Read `style-intake.md` before asking style questions. Follow this order.
+
+### 2.1 Style discovery (mandatory before style questions)
+
+Inspect local project sources first. Search automatically before asking the user for visual direction.
+
+Prioritize these sources:
+
+1. `Assets.xcassets`, app icons, illustrations, logos, color assets
+2. Existing screenshots and marketing folders:
+   - `.maestro/`
+   - `screenshots/`
+   - `AppStore/`
+   - `fastlane/screenshots/`
+   - `marketing/`
+3. Product docs and positioning:
+   - `README*`
+   - `CLAUDE.md`
+   - launch plans, landing-page copy, docs folders
+4. Design tokens and UI code:
+   - CSS variables
+   - SwiftUI colors, gradients, materials, typography choices
+   - web theme files and shared design constants
+5. Prior App Store artifacts if they exist:
+   - previous templates
+   - old screenshot campaigns
+   - localized marketing assets
+
+Extract and summarize at least these signals:
+
+- dominant colors and accent colors
+- overall contrast: dark, light, mixed, muted, vivid
+- UI density: airy, balanced, dense
+- shape language: sharp, soft, rounded, card-heavy, flat
+- iconography and illustration style
+- typography direction if visible
+- copy tone: calm, technical, playful, premium, warm, urgent
+- whether the app feels calm, technical, warm, energetic, polished, playful, etc.
+
+If the app style is clear:
+- summarize the detected signals to the user in plain language
+- confirm that you will build from that direction instead of restarting from a generic template language
+
+If the signals are weak, missing, or contradictory:
+- say what you found
+- ask focused follow-up questions about the uncertainty instead of asking a broad design questionnaire
+
+### 2.2 Intent interview (short, high-signal)
+
+Read `style-interview.md` and ask only the minimum needed. Keep it conversational. Do not dump every question at once.
+
+Required style questions when still needed:
+
+1. What feeling should the campaign project: premium, playful, editorial, utilitarian, technical, warm, etc.?
+2. Are there App Store references, brands, or screenshot sets that should influence the direction?
+3. What is visually forbidden: loud gradients, glassmorphism, dark-only, card grids, overly playful styling, etc.?
+4. What visual trait from the app itself must still be recognizable in the screenshots?
+
+Optional questions only when still unresolved:
+
+5. Preferred type direction or font personality
+6. Light, dark, or mixed bias
+7. Density preference: more air vs more information
+8. Whether the set should feel tightly consistent or visibly varied across slides
+
+### 2.3 Product information (still required)
+
+After style discovery starts, collect the remaining production inputs naturally:
 
 1. **App**: Name, what it does (1 sentence), main value proposition
 2. **Screenshots**: Where are the app captures? Search automatically first:
-   - Glob for: `.maestro/`, `screenshots/`, `AppStore/`, `fastlane/screenshots/`, `marketing/`
    - If found, show what you found and confirm
    - If not found, ask how the user generates them
    - Prefer clean simulator captures that show the app UI clearly. If the user can choose, prefer recent 6.1-inch iPhone captures as the source material
-3. **Visual style**: Brand colors, preferred font, dark/light/colorful preference, and App Store references if any
-   - If `Assets.xcassets`, `marketing/plan.md`, prior marketing, or brand assets exist, derive colors/font direction from there without asking
-   - If the user gives directional feedback like "more premium", "more bold", "more editorial", "more airy", or "more dense", treat that as a real design constraint
-4. **Features to highlight**: Prioritized list of features/benefits (recommend 3-5). Each slide = 1 feature
-5. **Hero assets**: App icon or other brand asset. Search automatically before asking
-6. **Slide count**: How many screenshots (recommend 3-5 to start, Apple allows up to 10)
+3. **Features to highlight**: Prioritized list of features/benefits (recommend 3-5). Each slide = 1 feature
+4. **Hero assets**: App icon or other brand asset. Search automatically before asking
+5. **Slide count**: How many screenshots (recommend 3-5 to start, Apple allows up to 10)
 
-### Optional (ask only if relevant)
+Optional only if relevant:
 
-7. **Device**: Default is `iPhone 16 Pro - Black Titanium - Portrait`. Only ask if iPad/Mac/other makes sense
-8. **Localization**: Only if the project already has xcstrings or multiple language support
-9. **Extra assets**: Floating UI elements, badges, supporting illustrations
-10. **Additional constraints**: Any required claims, forbidden styles, or marketing constraints
+6. **Device**: Default is `iPhone 16 Pro - Black Titanium - Portrait`. Only ask if iPad/Mac/other makes sense
+7. **Localization**: Only if the project already has xcstrings or multiple language support
+8. **Extra assets**: Floating UI elements, badges, supporting illustrations
+9. **Additional constraints**: Required claims, forbidden styles, or marketing constraints
 
-### Derived (do NOT ask — figure out automatically)
+### 2.4 Style decision (mandatory before HTML)
 
-- Background gradients (from brand colors)
+Before drafting templates, explicitly decide and internally lock these six items:
+
+- `brand signals detected`
+- `chosen campaign style`
+- `copy voice`
+- `background system`
+- `device composition rhythm`
+- `variation plan across slides`
+
+Each item must be justified by either:
+
+- app evidence from style discovery, or
+- direct user feedback from the interview
+
+If you cannot justify one of these, keep asking focused questions before designing.
+
+### Derived (do NOT ask unless blocked)
+
+- Background gradients or textures from brand colors and UI mood
 - Layout distribution (hero → feature-top → feature-bottom → alternating)
-- Headline copy (from features and value proposition)
-- Secondary palette (variations of brand colors)
+- Headline copy from features and value proposition
+- Secondary palette from the app's actual palette
 - Canvas class from `project.device` + `project.output_size` via `kou inspect-frame`
-- Whether the app name should appear in the slide at all. Default: omit it unless it adds real brand value at readable size
+- Whether the app name should appear at all. Default: omit it unless it adds real brand value at readable size
 - Whether the app icon should appear. Default: use it sparingly on hero or closing slides, not as a tiny decorative marker
 
-**Principle**: If context is available (CLAUDE.md, existing configs, marketing/plan.md, Assets.xcassets), use it without re-asking.
+**Principle**: if context is available locally, use it before asking. Style questions come after inspection, not before.
 
 ## Phase 3: Generate
 
@@ -115,31 +198,43 @@ Read `design-guide.md` before generating templates. Read `yaml-reference.md` bef
 3. Read `project.device` and `project.output_size` from the YAML
 4. Run `kou inspect-frame "<device>" --output-size <size> --output json` and use that geometry before writing CSS
 5. Draft the narrative arc and 2-3 headline/subtitle options per slide before touching layout. Pick the strongest one first. Copy quality comes before CSS
-6. Create `templates/` with HTML templates — **minimum 3 distinct layouts** (read `design-guide.md` for templates)
-7. Create `config.yaml` with koubou config (read `yaml-reference.md` for format)
-8. Use CSS that adapts to the canvas and copy length: use `vw` or `clamp()` deliberately, prefer CSS Grid, overlap, and absolute-positioned layers, and verify the final computed text scale on the real canvas
-9. **Before writing HTML**: plan text/device zones for each slide (which area owns what percentage of the canvas). Do not start CSS until zones are clear
-10. Run: `kou generate config.yaml --verbose`
-11. **Post-render QA** (mandatory — do not skip):
+6. Translate the style decision into a campaign brief:
+   - what the set should feel like
+   - what motifs are allowed
+   - what motifs are banned
+   - how much variation the first 5 slides should show
+7. Create `templates/` with HTML templates — **minimum 3 distinct layouts**, and the first 3 slides must not repeat the same composition archetype
+8. In HTML templates, annotate measurable layout elements with `data-kou-id`; add `data-kou-role` when it clarifies intent. Minimum annotations for most slides: headline, subtitle/supporting text, and main device image
+9. Create `config.yaml` with koubou config (read `yaml-reference.md` for format)
+10. Use CSS that adapts to the canvas and copy length: use `vw` or `clamp()` deliberately, prefer CSS Grid, overlap, and absolute-positioned layers, and verify the final computed text scale on the real canvas
+11. **Before writing HTML**: plan text/device zones for each slide (which area owns what percentage of the canvas). Do not start CSS until zones are clear
+12. Run: `kou generate config.yaml --output json`
+13. For each generated HTML screenshot, read `layout_path` from the JSON result and inspect the sidecar before deciding the layout is acceptable
+14. **Post-render QA** (mandatory — do not skip):
     - Review each generated slide visually
+    - Open each `*.layout.json` sidecar referenced by `layout_path`
     - Check against the rejection checklist in `design-guide.md`
+    - Check that the rendered set still reflects the app style you discovered instead of generic App Store defaults
+    - Use layout JSON only for objective geometry: positions, occupied space, proportions, and mathematical overlaps
+    - If `elements` is empty for an HTML slide that should be measured, treat that as missing or broken annotation and fix the template
     - Verify: no emoji icons, no identical card grids, no decentered devices, no text below minimum scale, no unintentional device cropping (device top/notch must be visible on hero slides; screen content must be readable)
     - Apply the logo-swap test: would these slides work for a competitor?
     - If any slide fails, fix and regenerate before showing to the user
-12. Open output folder: `open <output_dir>`
-13. Ask if the user wants adjustments — iterate on specific slides without regenerating everything
+15. Open output folder: `open <output_dir>`
+16. Ask if the user wants adjustments — iterate on specific slides without regenerating everything
 
 ### Iteration Rules
 
 - When user asks to change a specific slide, only modify that template + config entry
 - When user asks for a global style change (colors, fonts, mood, density, boldness), update all templates
-- Re-run `kou generate config.yaml --verbose` after changes
+- Re-run `kou generate config.yaml --output json` after changes so the new `layout_path` values and sidecars stay in sync
 - Use `kou live config.yaml` if user wants real-time preview while editing
 - If a slide feels small, first increase scale or switch layout. Do not hide the problem with extra gradients or labels
 - If copy forces tiny text, rewrite the copy or choose a more suitable layout; never accept a timid slide because "the text had to fit"
 - Keep variety high: the goal is campaign consistency, not layout repetition
 - Do not stop after the first successful render if the output still violates the design rules or rejection checklist
 - If the user asks for a mood change, reinterpret the whole set inside the quality limits instead of defending the previous defaults
+- If screenshot and layout JSON disagree, trust the rendered screenshot for taste and investigate the annotation or render timing instead of forcing a layout decision from stale geometry
 
 ## Hard Rules
 
@@ -173,6 +268,8 @@ Read `design-guide.md` before generating templates. Read `yaml-reference.md` bef
 - Do not present the first technically successful render as final — always review against the rejection checklist in design-guide.md
 - Do not let the rules flatten the creative direction. A strange but strong composition is valid if it stays readable and high-impact
 - Defaults can be broken when the final result is stronger, clearer, and more specific to the app
+- Do not start from the generic fallback of dark gradient + centered phone + big white headline unless the app genuinely supports that language or the user explicitly wants it
+- You should be able to explain to yourself why the campaign looks like this app and not a competitor with the same feature list
 
 ## Key Technical Details
 
@@ -188,6 +285,37 @@ To disable frame for a specific screenshot: set `frame: false` in its YAML defin
 
 - `variables:` in YAML → `{{key}}` in HTML → localizable text (extracted to xcstrings)
 - `assets:` in YAML → `{{key}}` in HTML → image file paths (pre-rendered with device frame)
+
+### Layout JSON for HTML screenshots
+
+For HTML screenshots, Koubou can emit a compact sidecar JSON with measured layout geometry.
+
+- Use `data-kou-id` on any element that should be measurable
+- Use `data-kou-role` only when the role helps the model interpret the element
+- Keep annotations minimal and structural, not exhaustive
+- Good defaults: annotate the main headline, supporting copy, and primary device or hero image
+
+Example:
+
+```html
+<h1 data-kou-id="headline" data-kou-role="headline">{{headline}}</h1>
+<p data-kou-id="subtitle" data-kou-role="supporting">{{subtitle}}</p>
+<img data-kou-id="device" data-kou-role="device" src="{{app_screenshot}}" alt="">
+```
+
+Generation workflow:
+
+- Run `kou generate config.yaml --output json`
+- Read `layout_path` from the command output
+- Open the referenced `*.layout.json`
+
+Interpretation rules:
+
+- Geometry fields are normalized ratios from `0..1`
+- `elements` contains only annotated nodes
+- `overlaps` contains only mathematical box intersections
+- Use this file to understand layout facts, not to decide taste
+- Do not invent subjective rules such as "too small" from the JSON alone; combine the geometry with the actual screenshot review
 
 ### Output structure
 

--- a/skills/koubou/capabilities-reference.md
+++ b/skills/koubou/capabilities-reference.md
@@ -18,6 +18,8 @@ screenshots:
       app_screenshot: "screenshots/home.png"
 ```
 
+When HTML contains `data-kou-id` annotations, `kou generate ... --output json` also returns `layout_path`, which points to a compact sidecar JSON containing normalized element geometry and mathematical overlaps for the final rendered layout.
+
 ### 2. Content YAML Mode (programmatic)
 
 Items positioned by coordinates. Useful for simple layouts without HTML.

--- a/skills/koubou/design-guide.md
+++ b/skills/koubou/design-guide.md
@@ -22,6 +22,54 @@ Plan slides as a story, not a feature list.
 - Pick the strongest screenshot for the hero, not just the first one available
 - If the source captures are weak, cropped badly, or inconsistent, ask for better captures before polishing CSS forever
 
+## Style Intake Before Narrative
+
+Before writing the narrative arc, inspect the app's real visual language. The screenshot campaign should feel like a stronger expression of the product, not a detached generic ad system.
+
+Read `style-intake.md` when gathering inputs. Do this before asking broad visual questions.
+
+### Signals to extract from the product
+
+| Signal | What to inspect | What it tells you |
+|---|---|---|
+| Dominant colors | App icon, color assets, theme tokens, screenshots | Brand palette, accent logic, warmth/coolness |
+| Contrast | Light/dark surfaces, text contrast, UI backgrounds | Whether the campaign should feel bright, moody, restrained, or vivid |
+| UI density | Screen layouts, card count, spacing, information load | Whether the campaign should simplify, condense, or preserve structure |
+| Corners and shadows | Cards, buttons, panels, materials | Whether the style feels soft, tactile, flat, glossy, or technical |
+| Iconography | SF Symbols, custom icons, illustrations, badges | How decorative or austere the campaign can be |
+| Copy tone | README, landing copy, UI text, onboarding | Whether headlines should feel calm, technical, warm, playful, or premium |
+| General feeling | Whole product impression | Calm, technical, warm, energetic, editorial, playful, etc. |
+
+### Translate product signals into screenshot direction
+
+| Product signal combination | Screenshot direction |
+|---|---|
+| Sober palette + austere type + dense UI | More editorial or utility-led campaign, less glossy, cleaner hierarchy |
+| Colorful UI + illustration + casual tone | More layered or playful campaign with richer depth and stronger accents |
+| Technical workflow UI + trust-sensitive product | Cleaner, structured, credibility-first campaign with restrained effects |
+| Warm palette + rounded cards + friendly voice | Softer, warmer, more tactile campaign with approachable copy |
+| Dark UI + neon/vivid accents | High-contrast campaign is valid, but avoid the generic dark-gradient fallback by varying composition and texture |
+| Neutral UI with weak branding | Let copy voice and strong UI crops carry identity instead of inventing unrelated decoration |
+
+### When not to copy the app literally
+
+- If the UI is too dense, simplify it for the campaign
+- If the UI is visually plain, amplify hierarchy and copy without inventing a foreign brand language
+- If the UI style hurts readability at thumbnail size, adapt it for App Store constraints while keeping brand truth
+
+### Style decision record
+
+Before touching layout, explicitly decide:
+
+- `brand signals detected`
+- `chosen campaign style`
+- `copy voice`
+- `background system`
+- `device composition rhythm`
+- `variation plan across slides`
+
+If any item is unsupported by app evidence or user direction, gather more information first.
+
 ## Source Material
 
 - Prefer clean simulator captures over noisy marketing exports
@@ -101,6 +149,17 @@ After generating, ask: "Could I replace this app's name with a competitor's and 
 | `clamp()` that can produce tiny text | Use `vw` or a safer `clamp()`, then verify the computed size on the target canvas |
 | Generic gradient (#667eea → #764ba2) | Derive from actual brand colors |
 | Buzzword headline | Concrete outcome in simple words |
+
+### Generic fallback warning
+
+The default AI failure mode is:
+
+- dark gradient
+- centered phone
+- large white headline
+- one mild tilt on a later slide
+
+Do not use this as a starting point unless the app really supports that language or the user explicitly asks for it. A valid set should feel grounded in the app's own palette, tone, and UI character.
 
 ## Device-Aware Typography
 
@@ -333,6 +392,19 @@ NEVER repeat the same layout in consecutive slides. Alternate between:
   - contrast slide vs device slide rhythm
 - Consistency should come from palette, typography family, and narrative arc, not from cloning the same composition
 - When the user asks for a specific direction, adapt the whole set to that mood without collapsing all slides into one repeated solution
+
+### Sameness check
+
+Reject the set if consecutive slides repeat too many of the same ingredients:
+
+- same background logic
+- same text block geometry
+- same device posture
+- same crop aggressiveness
+- same card/list motif
+- same emotional tone
+
+Campaign consistency should come from brand signals and narrative, not from reusing the same template shape.
 
 ## Closing Slide Rules
 

--- a/skills/koubou/style-intake.md
+++ b/skills/koubou/style-intake.md
@@ -1,0 +1,91 @@
+# Style Intake
+
+Read the app before you ask for art direction. The goal is to ground the screenshot campaign in the product's actual visual language, not in a generic App Store aesthetic.
+
+## Order Of Operations
+
+1. Inspect the app's local artifacts
+2. Extract concrete visual and tonal signals
+3. Decide what is trustworthy vs missing vs contradictory
+4. Ask only the questions needed to resolve uncertainty
+5. Lock the style decision before writing copy or HTML
+
+## What To Read
+
+Prioritize these sources in roughly this order:
+
+1. `Assets.xcassets`, app icons, logos, illustration assets
+2. Existing app screenshots, simulator exports, marketing captures
+3. Product docs: `README*`, `CLAUDE.md`, docs folders, launch plans
+4. Existing App Store work: `AppStore/`, `fastlane/screenshots/`, old templates
+5. UI code and design tokens:
+   - SwiftUI colors, gradients, fonts, materials
+   - CSS variables, theme files, design constants
+   - reusable card, button, and surface styles
+6. Landing pages or web marketing files if present
+
+If several sources disagree, trust the sources closest to the shipped UI first, then current marketing, then old screenshot sets.
+
+## What To Infer
+
+Extract and name the app's signals in plain language:
+
+- Palette: dominant colors, accents, neutrals, warmth/coolness
+- Contrast: light, dark, mixed, muted, high-contrast
+- Density: airy, balanced, dense
+- Surfaces: flat, layered, card-heavy, glossy, matte
+- Geometry: sharp, soft, rounded, oversized, minimal
+- Visual energy: calm, technical, warm, playful, editorial, energetic
+- Copy voice: precise, warm, friendly, premium, technical, punchy
+- Brand distinctives: icon shape, illustration language, recurring accent, signature gradient, recurring motif
+
+## What To Ask
+
+Ask questions only when the local evidence cannot answer them safely.
+
+Ask if:
+
+- brand signals are weak or inconsistent
+- the app UI is visually plain but the marketing needs a stronger identity
+- the product serves multiple audiences and the campaign direction is ambiguous
+- the app style works in-product but would be weak as App Store marketing
+- the user likely has explicit taste constraints not visible in the repo
+
+Do not ask for colors, fonts, or mood if they are already obvious from the app and marketing files. Instead, summarize what you found and confirm it.
+
+## Conflict Resolution
+
+Sometimes the app's UI style should not be copied literally into the screenshots.
+
+Use this order:
+
+1. Preserve brand truth
+2. Adapt for App Store readability and conversion
+3. Respect explicit user direction
+
+Examples:
+
+- If the app UI is neutral and utilitarian, the screenshot set can still be more dramatic, but it should retain the app's palette logic and tone.
+- If the UI is busy or dense, simplify the campaign rather than reproducing every visual detail.
+- If the user asks for a mood that conflicts with the shipped product, keep the product recognizable and say what you are amplifying or softening.
+
+## Heuristics: App Style -> Screenshot Style
+
+1. Minimal, high-contrast UI with restrained color usually wants a premium or editorial campaign, not playful gradients and stickers.
+2. Colorful UI with friendly copy and illustration can support more layered, energetic, and expressive screenshot compositions.
+3. Dense utility UI should usually become clearer and more selective in the campaign; keep the precision, remove the clutter.
+4. If the product relies on trust, privacy, finance, or workflow credibility, lean toward cleaner structure and stronger hierarchy over decorative depth.
+5. If the app's strongest brand signal is a specific accent color or shape, reuse that motif across slides so the set feels product-specific.
+6. If the UI uses soft radii, cards, and warm accents, the campaign can feel warmer and more tactile without copying every component.
+7. If the UI uses dark surfaces and vivid highlights, that does not automatically justify the generic dark-gradient fallback; keep the palette, but vary composition and texture.
+8. If the app has weak visual branding but strong product value, anchor the campaign in copy voice and UI crops instead of inventing unrelated visual gimmicks.
+
+## Minimum Output Of Intake
+
+Before designing, you should be able to state:
+
+- `brand signals detected`
+- `what should carry over into the campaign`
+- `what should be amplified for App Store marketing`
+- `what should be avoided`
+- `what remains uncertain and must be confirmed with the user`

--- a/skills/koubou/style-interview.md
+++ b/skills/koubou/style-interview.md
@@ -1,0 +1,80 @@
+# Style Interview
+
+Ask as little as possible, but ask the questions that materially change the campaign.
+
+The purpose of the interview is not to outsource taste to the user. It is to resolve what could not be learned from the app itself.
+
+## Question Bank
+
+Use short, direct questions. Ask only the ones needed.
+
+Core questions:
+
+1. What should the campaign feel like: premium, playful, editorial, utilitarian, technical, warm, or something else?
+2. Do you have any App Store screenshot sets, brands, or visual references you want me to borrow from?
+3. What should I avoid visually: loud gradients, glassmorphism, dark-only, heavy card grids, too much motion energy, etc.?
+4. What part of the app's real visual identity must still show up in the screenshots?
+
+Optional follow-ups:
+
+5. Should the set stay close to the shipped UI style, or can it be more dramatic than the app itself?
+6. Do you want more air or more density?
+7. Light, dark, or mixed overall mood?
+8. Should the campaign feel tightly uniform, or should each slide have stronger variation?
+9. Is there a font personality you prefer: neutral, elegant, playful, technical, editorial?
+
+## Conversation Patterns
+
+### Case 1: Branding is clear
+
+Use this when the repo already exposes strong signals.
+
+1. Summarize what you found:
+   - palette
+   - UI density
+   - tone
+   - distinctive motifs
+2. Confirm direction with one short question:
+   - "I’m reading this as a clean premium system with restrained color and dense UI. Should the screenshots stay close to that, or should I push them more editorial?"
+3. Ask only one or two missing taste questions if needed.
+
+### Case 2: Branding is weak or unclear
+
+Use this when the app UI is functional but visually noncommittal.
+
+1. State the uncertainty:
+   - "I found the product structure and screenshots, but the visual direction is pretty neutral."
+2. Ask for the campaign mood first.
+3. Ask for one reference or one anti-reference.
+4. Ask what real product trait must remain recognizable so the campaign still feels truthful.
+
+### Case 3: App style should not transfer literally
+
+Use this when the UI is dense, plain, or visually weak as marketing.
+
+1. Say what works in-product but not as a screenshot campaign.
+2. Propose the adaptation:
+   - keep palette/tone
+   - simplify density
+   - exaggerate hierarchy
+3. Ask for confirmation:
+   - "I’d keep the product’s sober palette and technical tone, but simplify the layout and push the typography much harder for App Store readability. Does that match what you want?"
+
+## Interview Rules
+
+- Do not ask more than necessary.
+- Do not ask broad questions that the repo already answers.
+- Do not ask style questions before looking at the project.
+- If the user gives directional words like "more premium", "less glossy", or "keep it calm", treat them as binding constraints.
+- If the user gives a reference, infer the reason behind it: typography, density, tone, palette, composition, or energy level.
+
+## Minimum Decision After Interview
+
+Before you design, be able to state:
+
+- chosen campaign style
+- copy voice
+- background system
+- device composition rhythm
+- variation level across slides
+- explicit bans or anti-patterns

--- a/skills/koubou/yaml-reference.md
+++ b/skills/koubou/yaml-reference.md
@@ -52,6 +52,16 @@ screenshots:
       app_screenshot: "screenshots/home.png"
 ```
 
+Recommended HTML annotation for measured layouts:
+
+```html
+<h1 data-kou-id="headline" data-kou-role="headline">{{headline}}</h1>
+<p data-kou-id="subtitle" data-kou-role="supporting">{{subtitle}}</p>
+<img data-kou-id="device" data-kou-role="device" src="{{app_screenshot}}" alt="">
+```
+
+When HTML elements are annotated this way, `kou generate config.yaml --output json` returns a `layout_path` for each generated screenshot, pointing to a compact `*.layout.json` sidecar with normalized geometry and overlaps.
+
 ### variables vs assets
 
 | Field | Template syntax | What it does | Localized? |

--- a/src/koubou/cli.py
+++ b/src/koubou/cli.py
@@ -360,8 +360,6 @@ body {
 }
 .page {
   position: relative;
-  width: 100%;
-  height: 100%;
   color: white;
 }
 .hero-page {
@@ -445,10 +443,10 @@ body {
 </head>
 <body class="page hero-page">
   <div class="copy">
-    <h1>{{headline}}</h1>
-    <p>{{subtitle}}</p>
+    <h1 data-kou-id="headline" data-kou-role="headline">{{headline}}</h1>
+    <p data-kou-id="subtitle" data-kou-role="subheadline">{{subtitle}}</p>
   </div>
-  <img class="device" src="{{screen}}" alt="">
+  <img class="device" data-kou-id="device" data-kou-role="device" src="{{screen}}" alt="">
 </body>
 </html>
 """,
@@ -460,10 +458,10 @@ body {
 </head>
 <body class="page feature-page feature-layout">
   <div class="copy">
-    <h1>{{headline}}</h1>
-    <p>{{subtitle}}</p>
+    <h1 data-kou-id="headline" data-kou-role="headline">{{headline}}</h1>
+    <p data-kou-id="subtitle" data-kou-role="subheadline">{{subtitle}}</p>
   </div>
-  <img class="device" src="{{screen}}" alt="">
+  <img class="device" data-kou-id="device" data-kou-role="device" src="{{screen}}" alt="">
 </body>
 </html>
 """,
@@ -475,8 +473,8 @@ body {
 </head>
 <body class="page closing-page">
   <div class="closing-stack">
-    <h1>{{headline}}</h1>
-    <p>{{subtitle}}</p>
+    <h1 data-kou-id="headline" data-kou-role="headline">{{headline}}</h1>
+    <p data-kou-id="subtitle" data-kou-role="subheadline">{{subtitle}}</p>
   </div>
 </body>
 </html>
@@ -498,7 +496,12 @@ def _show_results(results, output_dir: str) -> None:
     table.add_column("Status", style="green")
     table.add_column("Output Path", style="blue")
 
-    for name, path, success, error in results:
+    for entry in results:
+        if len(entry) == 5:
+            name, path, _layout_path, success, error = entry
+        else:
+            name, path, success, error = entry
+
         if success:
             status = "Success"
             output_path = str(path) if path else ""
@@ -519,6 +522,10 @@ def _project_uses_html_templates(project_config: ProjectConfig) -> bool:
         screenshot_def.template
         for screenshot_def in project_config.screenshots.values()
     )
+
+
+def _layout_output_path(output_path: Path) -> Path:
+    return output_path.with_suffix(".layout.json")
 
 
 def _prepare_html_environment(
@@ -739,9 +746,19 @@ def generate(
                 project_config.screenshots.items()
             ):
                 if i < len(result_paths):
-                    results.append((screenshot_id, result_paths[i], True, None))
+                    result_path = result_paths[i]
+                    layout_path = (
+                        _layout_output_path(result_path)
+                        if screenshot_def.template
+                        else None
+                    )
+                    results.append(
+                        (screenshot_id, result_path, layout_path, True, None)
+                    )
                 else:
-                    results.append((screenshot_id, None, False, "Generation failed"))
+                    results.append(
+                        (screenshot_id, None, None, False, "Generation failed")
+                    )
         except Exception as _e:
             stderr_console.print(f"Project generation failed: {_e}", style="red")
             raise typer.Exit(1)
@@ -751,16 +768,17 @@ def generate(
                 {
                     "name": name,
                     "path": str(path) if path else None,
+                    "layout_path": str(layout_path) if layout_path else None,
                     "success": success,
                     "error": error,
                 }
-                for name, path, success, error in results
+                for name, path, layout_path, success, error in results
             ]
             print(json.dumps(json_results))
         else:
             _show_results(results, project_config.project.output_dir)
 
-        failed_count = sum(1 for _, _, success, _ in results if not success)
+        failed_count = sum(1 for *_, success, _ in results if not success)
         if failed_count > 0:
             stderr_console.print(
                 f"\n{failed_count} screenshot(s) failed to generate",

--- a/src/koubou/cli.py
+++ b/src/koubou/cli.py
@@ -446,7 +446,13 @@ body {
     <h1 data-kou-id="headline" data-kou-role="headline">{{headline}}</h1>
     <p data-kou-id="subtitle" data-kou-role="subheadline">{{subtitle}}</p>
   </div>
-  <img class="device" data-kou-id="device" data-kou-role="device" src="{{screen}}" alt="">
+  <img
+    class="device"
+    data-kou-id="device"
+    data-kou-role="device"
+    src="{{screen}}"
+    alt=""
+  >
 </body>
 </html>
 """,
@@ -461,7 +467,13 @@ body {
     <h1 data-kou-id="headline" data-kou-role="headline">{{headline}}</h1>
     <p data-kou-id="subtitle" data-kou-role="subheadline">{{subtitle}}</p>
   </div>
-  <img class="device" data-kou-id="device" data-kou-role="device" src="{{screen}}" alt="">
+  <img
+    class="device"
+    data-kou-id="device"
+    data-kou-role="device"
+    src="{{screen}}"
+    alt=""
+  >
 </body>
 </html>
 """,

--- a/src/koubou/generator.py
+++ b/src/koubou/generator.py
@@ -407,6 +407,10 @@ class ScreenshotGenerator:
             cleanup_paths=cleanup_paths,
         )
 
+    def _resolve_layout_output_path(self, output_path: Path) -> Path:
+        """Resolve the sidecar layout JSON path for an HTML screenshot."""
+        return output_path.with_suffix(".layout.json")
+
     def _generate_html_screenshot(
         self,
         screenshot_def: Any,
@@ -438,14 +442,17 @@ class ScreenshotGenerator:
                     destination_dir=workspace_dir,
                     assets=prepared.assets,
                 )
-                png_bytes = self.html_renderer.render_staged(workspace_dir, output_size)
+                render_result = self.html_renderer.render_staged_with_layout(
+                    workspace_dir, output_size
+                )
         finally:
             prepared.cleanup()
 
         output_path = self._resolve_output_path(output_dir, screenshot_id, config_dir)
+        layout_path = self._resolve_layout_output_path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        img = Image.open(io.BytesIO(png_bytes))
+        img = Image.open(io.BytesIO(render_result.png_bytes))
         rgb_img = Image.new("RGB", img.size, (255, 255, 255))
         rgb_img.paste(img, mask=img if img.mode == "RGBA" else None)
 
@@ -453,6 +460,11 @@ class ScreenshotGenerator:
             rgb_img.save(output_path, "JPEG", quality=95)
         else:
             rgb_img.save(output_path, "PNG")
+
+        layout_path.write_text(
+            json.dumps(render_result.layout, separators=(",", ":")),
+            encoding="utf-8",
+        )
 
         logger.info(f"Generated HTML screenshot: {output_path}")
         return output_path

--- a/src/koubou/renderers/html_renderer.py
+++ b/src/koubou/renderers/html_renderer.py
@@ -1,10 +1,11 @@
 """HTML template renderer using Playwright headless browser."""
 
+from dataclasses import dataclass
 import logging
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from ..html_setup import (
     browser_setup_message,
@@ -13,6 +14,119 @@ from ..html_setup import (
 from .html_staging import stage_html_workspace
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HtmlRenderResult:
+    """Rendered PNG bytes plus compact layout metadata."""
+
+    png_bytes: bytes
+    layout: Dict[str, Any]
+
+
+def _round_ratio(value: float) -> float:
+    """Round normalized values for smaller, stable JSON payloads."""
+    return round(value, 4)
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    return min(max(value, lower), upper)
+
+
+def _normalize_box(
+    raw_element: Dict[str, Any], canvas_width: int, canvas_height: int
+) -> Dict[str, float]:
+    """Clip an element rect to the canvas and normalize it to 0..1 ratios."""
+    left = _clamp(float(raw_element["left"]), 0.0, float(canvas_width))
+    top = _clamp(float(raw_element["top"]), 0.0, float(canvas_height))
+    right = _clamp(float(raw_element["right"]), 0.0, float(canvas_width))
+    bottom = _clamp(float(raw_element["bottom"]), 0.0, float(canvas_height))
+
+    if right < left:
+        right = left
+    if bottom < top:
+        bottom = top
+
+    return {
+        "x": left / canvas_width,
+        "y": top / canvas_height,
+        "width": (right - left) / canvas_width,
+        "height": (bottom - top) / canvas_height,
+    }
+
+
+def _build_layout_manifest(
+    raw_elements: List[Dict[str, Any]], size: Tuple[int, int]
+) -> Dict[str, Any]:
+    """Convert raw DOM measurements into the compact JSON layout contract."""
+    canvas_width, canvas_height = size
+    normalized_elements: List[Dict[str, Any]] = []
+    overlap_boxes: List[Tuple[str, Dict[str, float]]] = []
+
+    for raw_element in raw_elements:
+        box = _normalize_box(raw_element, canvas_width, canvas_height)
+        element: Dict[str, Any] = {
+            "id": raw_element["id"],
+            "x": _round_ratio(box["x"]),
+            "y": _round_ratio(box["y"]),
+            "width": _round_ratio(box["width"]),
+            "height": _round_ratio(box["height"]),
+        }
+
+        role = raw_element.get("role")
+        if role:
+            element["role"] = role
+
+        text = raw_element.get("text")
+        if text:
+            element["text"] = text
+
+        src = raw_element.get("src")
+        if src:
+            element["src"] = src
+
+        z_index = raw_element.get("zIndex")
+        if z_index is not None:
+            element["zIndex"] = z_index
+
+        normalized_elements.append(element)
+        overlap_boxes.append((raw_element["id"], box))
+
+    overlaps: List[Dict[str, Any]] = []
+    for index, (first_id, first_box) in enumerate(overlap_boxes):
+        first_right = first_box["x"] + first_box["width"]
+        first_bottom = first_box["y"] + first_box["height"]
+
+        for second_id, second_box in overlap_boxes[index + 1 :]:
+            second_right = second_box["x"] + second_box["width"]
+            second_bottom = second_box["y"] + second_box["height"]
+
+            overlap_x = max(first_box["x"], second_box["x"])
+            overlap_y = max(first_box["y"], second_box["y"])
+            overlap_right = min(first_right, second_right)
+            overlap_bottom = min(first_bottom, second_bottom)
+            overlap_width = overlap_right - overlap_x
+            overlap_height = overlap_bottom - overlap_y
+
+            if overlap_width <= 0 or overlap_height <= 0:
+                continue
+
+            overlaps.append(
+                {
+                    "first": first_id,
+                    "second": second_id,
+                    "x": _round_ratio(overlap_x),
+                    "y": _round_ratio(overlap_y),
+                    "width": _round_ratio(overlap_width),
+                    "height": _round_ratio(overlap_height),
+                }
+            )
+
+    return {
+        "version": 1,
+        "elements": normalized_elements,
+        "overlaps": overlaps,
+    }
 
 
 class HtmlRenderer:
@@ -47,6 +161,21 @@ class HtmlRenderer:
         size: Tuple[int, int],
         assets: Optional[Dict[str, str]] = None,
     ) -> bytes:
+        """Render an HTML template to PNG bytes."""
+        return self.render_with_layout(
+            template_path=template_path,
+            variables=variables,
+            size=size,
+            assets=assets,
+        ).png_bytes
+
+    def render_with_layout(
+        self,
+        template_path: Path,
+        variables: Dict[str, str],
+        size: Tuple[int, int],
+        assets: Optional[Dict[str, str]] = None,
+    ) -> HtmlRenderResult:
         """Render an HTML template to PNG bytes.
 
         Args:
@@ -56,7 +185,7 @@ class HtmlRenderer:
             assets: Dict of {relative_name: absolute_path} to symlink into sandbox
 
         Returns:
-            PNG image bytes
+            Rendered PNG bytes plus compact layout JSON data
         """
         self._ensure_browser()
         assert self._browser is not None
@@ -73,18 +202,24 @@ class HtmlRenderer:
             )
 
             # Render with Playwright
-            png_bytes = self.render_staged(index_path.parent, size)
+            result = self.render_staged_with_layout(index_path.parent, size)
 
             logger.info(
                 f"Rendered HTML template {template_path.name} " f"at {width}x{height}"
             )
-            return png_bytes
+            return result
 
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
     def render_staged(self, workspace_dir: Path, size: Tuple[int, int]) -> bytes:
         """Render a pre-staged HTML workspace directory to PNG bytes."""
+        return self.render_staged_with_layout(workspace_dir, size).png_bytes
+
+    def render_staged_with_layout(
+        self, workspace_dir: Path, size: Tuple[int, int]
+    ) -> HtmlRenderResult:
+        """Render a pre-staged HTML workspace directory and extract layout data."""
         self._ensure_browser()
         assert self._browser is not None
 
@@ -97,7 +232,104 @@ class HtmlRenderer:
             page.goto(
                 f"file://{workspace_dir / 'index.html'}", wait_until="networkidle"
             )
-            return page.screenshot(type="png", full_page=False)
+            raw_elements = page.evaluate(
+                """async () => {
+                    if (document.readyState !== "complete") {
+                        await new Promise((resolve) => {
+                            window.addEventListener("load", resolve, { once: true });
+                        });
+                    }
+
+                    const stylesheetLinks = Array.from(
+                        document.querySelectorAll('link[rel="stylesheet"]')
+                    );
+                    await Promise.all(
+                        stylesheetLinks.map(async (link) => {
+                            if (link.sheet) {
+                                return;
+                            }
+
+                            await new Promise((resolve) => {
+                                link.addEventListener("load", resolve, { once: true });
+                                link.addEventListener("error", resolve, { once: true });
+                            });
+                        })
+                    );
+
+                    if (document.fonts && document.fonts.ready) {
+                        try {
+                            await document.fonts.ready;
+                        } catch (error) {
+                            // Ignore font readiness errors and fall back to current layout.
+                        }
+                    }
+
+                    const images = Array.from(document.images);
+                    await Promise.all(
+                        images.map(async (image) => {
+                            if (!image.complete) {
+                                await new Promise((resolve, reject) => {
+                                    image.addEventListener("load", resolve, { once: true });
+                                    image.addEventListener("error", reject, { once: true });
+                                }).catch(() => undefined);
+                            }
+
+                            if (typeof image.decode === "function") {
+                                try {
+                                    await image.decode();
+                                } catch (error) {
+                                    // Ignore decode failures and use the current layout.
+                                }
+                            }
+                        })
+                    );
+
+                    await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+
+                    return Array.from(document.querySelectorAll("[data-kou-id]"))
+                        .map((node) => {
+                            const rect = node.getBoundingClientRect();
+                            const style = window.getComputedStyle(node);
+                            const element = {
+                                id: node.getAttribute("data-kou-id"),
+                                left: rect.left,
+                                top: rect.top,
+                                right: rect.right,
+                                bottom: rect.bottom,
+                            };
+
+                            const role = node.getAttribute("data-kou-role");
+                            if (role) {
+                                element.role = role;
+                            }
+
+                            const text = (node.innerText || "").replace(/\\s+/g, " ").trim();
+                            if (text) {
+                                element.text = text;
+                            }
+
+                            if (node.tagName.toLowerCase() === "img") {
+                                const src = node.getAttribute("src");
+                                if (src) {
+                                    element.src = src;
+                                }
+                            }
+
+                            if (style.zIndex && style.zIndex !== "auto") {
+                                const parsedZIndex = Number(style.zIndex);
+                                if (Number.isFinite(parsedZIndex)) {
+                                    element.zIndex = parsedZIndex;
+                                }
+                            }
+
+                            return element;
+                        })
+                        .filter((element) => Boolean(element.id));
+                }"""
+            )
+            png_bytes = page.screenshot(type="png", full_page=False)
+            layout = _build_layout_manifest(raw_elements, size)
+            return HtmlRenderResult(png_bytes=png_bytes, layout=layout)
         finally:
             page.close()
 

--- a/src/koubou/renderers/html_renderer.py
+++ b/src/koubou/renderers/html_renderer.py
@@ -1,9 +1,9 @@
 """HTML template renderer using Playwright headless browser."""
 
-from dataclasses import dataclass
 import logging
 import shutil
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -260,7 +260,8 @@ class HtmlRenderer:
                         try {
                             await document.fonts.ready;
                         } catch (error) {
-                            // Ignore font readiness errors and fall back to current layout.
+                            // Ignore font readiness errors and fall back
+                            // to the current layout.
                         }
                     }
 
@@ -269,8 +270,16 @@ class HtmlRenderer:
                         images.map(async (image) => {
                             if (!image.complete) {
                                 await new Promise((resolve, reject) => {
-                                    image.addEventListener("load", resolve, { once: true });
-                                    image.addEventListener("error", reject, { once: true });
+                                    image.addEventListener(
+                                        "load",
+                                        resolve,
+                                        { once: true }
+                                    );
+                                    image.addEventListener(
+                                        "error",
+                                        reject,
+                                        { once: true }
+                                    );
                                 }).catch(() => undefined);
                             }
 
@@ -278,13 +287,16 @@ class HtmlRenderer:
                                 try {
                                     await image.decode();
                                 } catch (error) {
-                                    // Ignore decode failures and use the current layout.
+                                    // Ignore decode failures and use the
+                                    // current layout.
                                 }
                             }
                         })
                     );
 
-                    await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+                    await new Promise((resolve) =>
+                        requestAnimationFrame(() => resolve())
+                    );
 
                     return Array.from(document.querySelectorAll("[data-kou-id]"))
                         .map((node) => {
@@ -303,7 +315,9 @@ class HtmlRenderer:
                                 element.role = role;
                             }
 
-                            const text = (node.innerText || "").replace(/\\s+/g, " ").trim();
+                            const text = (node.innerText || "")
+                                .replace(/\\s+/g, " ")
+                                .trim();
                             if (text) {
                                 element.text = text;
                             }

--- a/src/koubou/renderers/html_staging.py
+++ b/src/koubou/renderers/html_staging.py
@@ -26,6 +26,14 @@ def _symlink_or_copy(source: Path, destination: Path) -> None:
             shutil.copy2(source, destination)
 
 
+def _copy_item(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.is_dir():
+        shutil.copytree(source, destination)
+    else:
+        shutil.copy2(source, destination)
+
+
 def stage_html_workspace(
     *,
     template_path: Path,
@@ -51,7 +59,8 @@ def stage_html_workspace(
         target = destination_dir / item.name
         if target.exists() or target.is_symlink():
             _remove_existing(target)
-        _symlink_or_copy(item, target)
+        # Copy template siblings to avoid browser quirks with file:// symlinked CSS.
+        _copy_item(item, target)
 
     if assets:
         for rel_name, abs_path in assets.items():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -473,7 +473,10 @@ class TestCLI:
         )
 
         assert result.exit_code == 0
-        payload = json.loads(result.stdout)
+        json_line = next(
+            line for line in reversed(result.stdout.splitlines()) if line.strip()
+        )
+        payload = json.loads(json_line)
         assert payload == [
             {
                 "name": "hero",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -427,6 +427,71 @@ class TestCLI:
             }
         ]
 
+    def test_generate_json_includes_layout_path_for_html(self, monkeypatch):
+        """HTML JSON output should expose the sidecar layout path."""
+        template_path = self.temp_dir / "hero.html"
+        template_path.write_text("<html><body>{{headline}}</body></html>")
+
+        output_dir = self.temp_dir / "output"
+        config_data = {
+            "project": {
+                "name": "HTML CLI JSON Test",
+                "output_dir": str(output_dir),
+                "device": "iPhone 16 Pro - Black Titanium - Portrait",
+                "output_size": "iPhone6_9",
+            },
+            "screenshots": {
+                "hero": {
+                    "template": str(template_path),
+                    "variables": {"headline": "Hello"},
+                }
+            },
+        }
+        config_path = self.temp_dir / "html_json_config.yaml"
+        with open(config_path, "w") as f:
+            yaml.dump(config_data, f)
+
+        def fake_prepare_html_environment(*, setup_requested, verbose, output_console):
+            return None
+
+        class FakeGenerator:
+            def generate_project(self, project_config, config_dir):
+                return [
+                    output_dir
+                    / "iPhone_16_Pro_-_Black_Titanium_-_Portrait"
+                    / "hero.png"
+                ]
+
+        monkeypatch.setattr(
+            "koubou.cli._prepare_html_environment", fake_prepare_html_environment
+        )
+        monkeypatch.setattr("koubou.cli.ScreenshotGenerator", FakeGenerator)
+
+        result = self.runner.invoke(
+            app,
+            ["generate", str(config_path), "--output", "json"],
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload == [
+            {
+                "name": "hero",
+                "path": str(
+                    output_dir
+                    / "iPhone_16_Pro_-_Black_Titanium_-_Portrait"
+                    / "hero.png"
+                ),
+                "layout_path": str(
+                    output_dir
+                    / "iPhone_16_Pro_-_Black_Titanium_-_Portrait"
+                    / "hero.layout.json"
+                ),
+                "success": True,
+                "error": None,
+            }
+        ]
+
     def test_generate_html_without_setup_shows_actionable_error(self, monkeypatch):
         """Test generate shows kou setup-html guidance when HTML is not ready."""
         template_path = self.temp_dir / "hero.html"

--- a/tests/test_html_renderer.py
+++ b/tests/test_html_renderer.py
@@ -2,6 +2,7 @@
 
 import importlib
 import io
+import json
 import shutil
 import tempfile
 from pathlib import Path
@@ -87,6 +88,103 @@ class TestScreenshotDefinitionValidation:
         )
         assert defn.content is not None
         assert defn.template is None
+
+
+class TestLayoutManifestHelpers:
+    """Unit tests for compact layout JSON helpers."""
+
+    def test_build_layout_manifest_with_overlap(self):
+        from koubou.renderers.html_renderer import _build_layout_manifest
+
+        manifest = _build_layout_manifest(
+            [
+                {
+                    "id": "headline",
+                    "role": "headline",
+                    "text": "Track every expense",
+                    "left": 40,
+                    "top": 80,
+                    "right": 360,
+                    "bottom": 240,
+                },
+                {
+                    "id": "phone",
+                    "role": "device",
+                    "src": "app_screenshot.png",
+                    "left": 200,
+                    "top": 180,
+                    "right": 520,
+                    "bottom": 700,
+                    "zIndex": 2,
+                },
+            ],
+            (800, 1000),
+        )
+
+        assert manifest == {
+            "version": 1,
+            "elements": [
+                {
+                    "id": "headline",
+                    "role": "headline",
+                    "text": "Track every expense",
+                    "x": 0.05,
+                    "y": 0.08,
+                    "width": 0.4,
+                    "height": 0.16,
+                },
+                {
+                    "id": "phone",
+                    "role": "device",
+                    "src": "app_screenshot.png",
+                    "x": 0.25,
+                    "y": 0.18,
+                    "width": 0.4,
+                    "height": 0.52,
+                    "zIndex": 2,
+                },
+            ],
+            "overlaps": [
+                {
+                    "first": "headline",
+                    "second": "phone",
+                    "x": 0.25,
+                    "y": 0.18,
+                    "width": 0.2,
+                    "height": 0.06,
+                }
+            ],
+        }
+
+    def test_build_layout_manifest_clips_to_canvas(self):
+        from koubou.renderers.html_renderer import _build_layout_manifest
+
+        manifest = _build_layout_manifest(
+            [
+                {
+                    "id": "offscreen",
+                    "left": -40,
+                    "top": -20,
+                    "right": 120,
+                    "bottom": 80,
+                }
+            ],
+            (200, 100),
+        )
+
+        assert manifest == {
+            "version": 1,
+            "elements": [
+                {
+                    "id": "offscreen",
+                    "x": 0.0,
+                    "y": 0.0,
+                    "width": 0.6,
+                    "height": 0.8,
+                }
+            ],
+            "overlaps": [],
+        }
 
 
 @requires_playwright
@@ -199,7 +297,8 @@ class TestHtmlRenderer:
             """<!DOCTYPE html>
 <html>
 <body style="margin:0; background:#1a1a2e; width:100vw; height:100vh;">
-  <h1 style="color:white; text-align:center; padding-top:40%;">
+  <h1 data-kou-id="headline" data-kou-role="headline"
+      style="color:white; text-align:center; padding-top:40%;">
     {{headline}}
   </h1>
 </body>
@@ -228,9 +327,39 @@ class TestHtmlRenderer:
 
         assert len(results) == 1
         assert results[0].exists()
+        assert results[0].with_suffix(".layout.json").exists()
 
         img = Image.open(results[0])
         assert img.size == (1320, 2868)
+
+        layout = json.loads(results[0].with_suffix(".layout.json").read_text())
+        assert layout["version"] == 1
+        assert len(layout["elements"]) == 1
+        assert layout["elements"][0]["id"] == "headline"
+        assert layout["elements"][0]["role"] == "headline"
+        assert layout["overlaps"] == []
+
+    def test_render_staged_with_layout_returns_empty_manifest_without_annotations(
+        self, temp_dir, renderer
+    ):
+        template = temp_dir / "plain.html"
+        template.write_text(
+            """<!DOCTYPE html>
+<html>
+<body style="margin:0; width:100vw; height:100vh; background:#fff;">
+  <p>Hello</p>
+</body>
+</html>"""
+        )
+
+        result = renderer.render_with_layout(
+            template_path=template,
+            variables={},
+            size=(400, 800),
+        )
+
+        assert len(result.png_bytes) > 0
+        assert result.layout == {"version": 1, "elements": [], "overlaps": []}
 
 
 class TestDependencyAnalyzerHtml:


### PR DESCRIPTION
## Why this matters
Koubou can already render beautiful HTML screenshots, but an LLM looking only at the template has no reliable way to understand the final composition.

HTML alone does not tell the model where things actually ended up after CSS, fonts, image loading, frame compositing, and viewport layout. That makes layout review brittle: the model can miss that a device image is tiny, that copy is pushed too low, or that two elements are physically colliding.

This PR gives every HTML screenshot a compact geometry sidecar so agents can reason about the real rendered layout instead of guessing from source code.

## What changed
- Add `<screenshot_id>.layout.json` next to each rendered HTML screenshot PNG
- Measure the final rendered DOM in Playwright after layout-critical resources are ready
- Export only annotated elements via `data-kou-id`, with optional `data-kou-role`
- Normalize all geometry to `0..1` ratios of the final canvas so the data is stable and compact
- Compute mathematical overlaps directly from bounding boxes
- Expose `layout_path` in `kou generate --output json`
- Annotate the sample/example HTML templates so the feature is discoverable immediately
- Document the contract in the README, YAML API docs, and Koubou skill docs

## JSON contract
Each sidecar stays intentionally small and objective.

Root keys:
- `version`
- `elements`
- `overlaps`

Each exported element contains:
- `id`
- `x`
- `y`
- `width`
- `height`
- optional `role`
- optional `text`
- optional `src`
- optional `zIndex`

Each overlap contains:
- `first`
- `second`
- `x`
- `y`
- `width`
- `height`

This is not a heuristic scoring system. Koubou does not decide whether a layout is good or bad. It only reports the measurable facts.

## Why this is important for LLM workflows
This turns the rendered screenshot into something an agent can inspect with much more reliability:
- where the headline actually sits on the canvas
- how much space the device occupies
- whether annotated elements intersect in the final render
- how copy and imagery are distributed without dumping a huge verbose manifest

That is a major step toward agent-friendly screenshot generation and review, because the model can now combine:
- the screenshot itself for taste and visual judgment
- the compact layout JSON for precise geometry

## Follow-up included in this PR
The PR also tightens the surrounding workflow so this feature is usable in practice:
- HTML render staging now avoids file URL quirks around sibling CSS
- layout extraction waits for fonts, stylesheets, and images before measuring
- the Koubou skill was updated so agents know to annotate HTML, generate with `--output json`, read `layout_path`, and use the sidecar correctly
- docs now explain both the quick-start flow and the exact contract

## Validation
Full feature validation:
- `/Users/davidcollado/Projects/koubou/.venv/bin/pytest tests/`

Follow-up validation after the lint/test stability fixes:
- `black --check src tests`
- `isort --check-only --diff src tests`
- `flake8 src tests`
- `mypy src`
- `pytest tests/test_cli.py -k 'layout_path_for_html or setup_html' -q`
- `pytest tests/test_html_renderer.py -q`
