### PR TITLE
Support transparent screenshot backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ project:
 
 defaults:                    # Default settings applied to all screenshots
   background:                # Default background configuration
-    type: "solid" | "linear" | "radial" | "conic"
+    type: "solid" | "linear" | "radial" | "conic" | "transparent"
     colors: [string, ...]    # Hex colors array
     direction: float?        # Degrees for gradients (default: 0)
 ```
@@ -577,11 +577,15 @@ screenshots:
 ### Background Configuration
 ```yaml
 background:
-  type: "solid" | "linear" | "radial" | "conic"
+  type: "solid" | "linear" | "radial" | "conic" | "transparent"
   colors: [string, ...]      # Hex colors (e.g., ["#667eea", "#764ba2"])
   direction: float?          # Degrees for linear gradients (default: 0)
   center: [string, string]?  # Center point for radial/conic ["x%", "y%"]
 ```
+
+Use `type: "transparent"` or an 8-digit hex color with alpha (for example
+`"#00000000"`) to preserve transparency in PNG output. JPEG output is always
+flattened over white.
 
 ### Content Items
 ```yaml

--- a/docs/yaml-api.md
+++ b/docs/yaml-api.md
@@ -540,8 +540,8 @@ Professional background rendering with gradients and solid colors.
 
 ```yaml
 background:
-  type: "solid" | "linear" | "radial" | "conic"  # Background type (required)
-  colors: [string, ...]      # Array of hex colors (required)
+  type: "solid" | "linear" | "radial" | "conic" | "transparent"  # Required
+  colors: [string, ...]      # Array of hex colors (not used for transparent)
   
   # Linear gradient options:
   direction: float?          # Direction in degrees (default: 0)
@@ -557,6 +557,20 @@ background:
 background:
   type: "solid"
   colors: ["#667eea"]        # Single color required
+```
+
+#### Transparent Background
+```yaml
+background:
+  type: "transparent"        # Preserves alpha in PNG output
+```
+
+You can also use an 8-digit hex color with alpha:
+
+```yaml
+background:
+  type: "solid"
+  colors: ["#00000000"]
 ```
 
 #### Linear Gradient
@@ -584,7 +598,9 @@ background:
 ```
 
 ### Color Format
-Colors must be in hex format: `#RRGGBB` or `#RRGGBBAA`
+Colors must be in hex format: `#RGB`, `#RRGGBB`, or `#RRGGBBAA`.
+PNG output preserves alpha when the background explicitly uses transparency.
+JPEG output is always flattened over white.
 
 ---
 

--- a/src/koubou/config.py
+++ b/src/koubou/config.py
@@ -74,10 +74,10 @@ def validate_hex_color(color: str, field_name: str = "Color") -> None:
 class GradientConfig(BaseModel):
     """Universal gradient configuration for text and backgrounds."""
 
-    type: Literal["solid", "linear", "radial", "conic"] = Field(
+    type: Literal["solid", "linear", "radial", "conic", "transparent"] = Field(
         ..., description="Gradient type"
     )
-    colors: List[str] = Field(..., description="List of hex colors")
+    colors: List[str] = Field(default_factory=list, description="List of hex colors")
     positions: Optional[List[float]] = Field(
         default=None, description="Color stop positions (0.0-1.0)"
     )
@@ -96,17 +96,7 @@ class GradientConfig(BaseModel):
 
     @field_validator("colors")
     @classmethod
-    def validate_colors(cls, v: List[str], info: ValidationInfo) -> List[str]:
-        gradient_type = info.data.get("type")
-
-        # Validate minimum colors based on type
-        if gradient_type == "solid" and len(v) != 1:
-            raise ValueError("Solid backgrounds require exactly 1 color")
-        elif gradient_type in ["linear", "radial", "conic"] and len(v) < 2:
-            raise ValueError("Gradients require at least 2 colors")
-        elif not v:
-            raise ValueError("At least one color is required")
-
+    def validate_colors(cls, v: List[str]) -> List[str]:
         # Validate color format
         for i, color in enumerate(v):
             try:
@@ -115,6 +105,20 @@ class GradientConfig(BaseModel):
                 # Re-raise with more context
                 raise ValueError(str(e)) from None
         return v
+
+    @model_validator(mode="after")
+    def validate_color_count(self):
+        """Validate color count after defaults have been applied."""
+        if self.type == "transparent":
+            if self.colors:
+                raise ValueError("Transparent backgrounds do not accept colors")
+        elif self.type == "solid" and len(self.colors) != 1:
+            raise ValueError("Solid backgrounds require exactly 1 color")
+        elif self.type in ["linear", "radial", "conic"] and len(self.colors) < 2:
+            raise ValueError("Gradients require at least 2 colors")
+        elif not self.colors:
+            raise ValueError("At least one color is required")
+        return self
 
     @field_validator("positions")
     @classmethod

--- a/src/koubou/generator.py
+++ b/src/koubou/generator.py
@@ -578,15 +578,16 @@ class ScreenshotGenerator:
             # Ensure output directory exists
             output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # Convert RGBA to RGB to remove alpha channel
-            # App Store does not accept images with alpha channels
-            rgb_canvas = Image.new("RGB", canvas.size, (255, 255, 255))
-            rgb_canvas.paste(canvas, mask=canvas)
-
             # Save based on file extension
             if output_path.suffix.lower() == ".jpg":
+                rgb_canvas = self._flatten_to_rgb(canvas)
                 rgb_canvas.save(output_path, "JPEG", quality=95)
+            elif self._should_preserve_alpha(config.background):
+                canvas.save(output_path, "PNG")
             else:
+                # App Store screenshots should not include alpha unless the
+                # background explicitly requests transparency.
+                rgb_canvas = self._flatten_to_rgb(canvas)
                 rgb_canvas.save(output_path, "PNG")
 
             logger.info(f"✅ Generated: {config.name}")
@@ -597,6 +598,24 @@ class ScreenshotGenerator:
             raise RenderError(
                 f"Failed to generate screenshot '{config.name}': {_e}"
             ) from _e
+
+    def _flatten_to_rgb(self, image: Image.Image) -> Image.Image:
+        """Composite an RGBA image over white and return RGB output."""
+        rgb_image = Image.new("RGB", image.size, (255, 255, 255))
+        rgb_image.paste(image, mask=image if image.mode == "RGBA" else None)
+        return rgb_image
+
+    def _should_preserve_alpha(self, background: Optional[GradientConfig]) -> bool:
+        """Return whether PNG output should keep transparency."""
+        if background is None:
+            return False
+        if background.type == "transparent":
+            return True
+        for color in background.colors:
+            hex_color = color.lstrip("#")
+            if len(hex_color) == 8 and int(hex_color[6:8], 16) < 255:
+                return True
+        return False
 
     def _load_source_image(self, image_path: str) -> Image.Image:
         """Load and validate source image."""
@@ -1400,9 +1419,13 @@ class ScreenshotGenerator:
             background_config = screenshot_def.background
         elif default_background:
             # Fallback to project default background
+            default_background_type = default_background.get("type", "solid")
             background_config = GradientConfig(
-                type=default_background.get("type", "solid"),
-                colors=default_background.get("colors", ["#ffffff"]),
+                type=default_background_type,
+                colors=default_background.get(
+                    "colors",
+                    [] if default_background_type == "transparent" else ["#ffffff"],
+                ),
                 direction=default_background.get("direction", 0),
                 positions=default_background.get("positions"),
                 center=default_background.get("center"),

--- a/src/koubou/renderers/background.py
+++ b/src/koubou/renderers/background.py
@@ -30,7 +30,9 @@ class BackgroundRenderer:
             BackgroundRenderError: If rendering fails
         """
         try:
-            if background_config.type == "solid":
+            if background_config.type == "transparent":
+                self._render_transparent(canvas)
+            elif background_config.type == "solid":
                 self._render_solid(background_config, canvas)
             else:
                 # Use unified gradient renderer for all gradients
@@ -53,6 +55,11 @@ class BackgroundRenderer:
 
         # Create solid color overlay
         overlay = Image.new("RGBA", canvas.size, color)
+        canvas.paste(overlay, (0, 0))
+
+    def _render_transparent(self, canvas: Image.Image) -> None:
+        """Render a fully transparent background."""
+        overlay = Image.new("RGBA", canvas.size, (255, 255, 255, 0))
         canvas.paste(overlay, (0, 0))
 
     def _parse_color(self, color_string: str) -> Tuple[int, int, int, int]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,17 @@ class TestGradientConfig:
         assert config.colors == ["#ff0000", "#00ff00"]
         assert config.direction == 45
 
+    def test_transparent_background_valid(self):
+        """Test transparent background configuration."""
+        config = GradientConfig(type="transparent")
+        assert config.type == "transparent"
+        assert config.colors == []
+
+    def test_transparent_background_rejects_colors(self):
+        """Test transparent background does not accept colors."""
+        with pytest.raises(ValidationError, match="do not accept colors"):
+            GradientConfig(type="transparent", colors=["#00000000"])
+
     def test_gradient_insufficient_colors(self):
         """Test gradient with insufficient colors fails validation."""
         with pytest.raises(ValidationError, match="at least 2 colors"):

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -228,6 +228,39 @@ class TestScreenshotGenerator:
         for result_path in results:
             assert result_path.exists()
 
+    def test_project_default_background_with_alpha_preserves_png_alpha(self):
+        """Test YAML-style default background alpha is preserved in PNG output."""
+        from koubou.config import ContentItem, ProjectInfo, ScreenshotDefinition
+
+        project_config = ProjectConfig(
+            project=ProjectInfo(
+                name="Transparent Project",
+                output_dir=str(self.temp_dir / "project_transparent_output"),
+                device="iPhone 15 Pro Portrait",
+                output_size=(400, 800),
+            ),
+            defaults={"background": {"type": "solid", "colors": ["#00000000"]}},
+            screenshots={
+                "transparent": ScreenshotDefinition(
+                    content=[
+                        ContentItem(
+                            type="image",
+                            asset=str(self.source_image_path),
+                            position=("50%", "50%"),
+                        )
+                    ],
+                    frame=False,
+                )
+            },
+        )
+
+        results = self.generator.generate_project(project_config)
+
+        assert len(results) == 1
+        output_image = Image.open(results[0])
+        assert output_image.mode == "RGBA"
+        assert output_image.getpixel((0, 0))[3] == 0
+
     def test_png_has_no_alpha_channel(self):
         """Test that PNG files don't have alpha (App Store requirement)."""
         config = ScreenshotConfig(
@@ -250,6 +283,39 @@ class TestScreenshotGenerator:
         assert (
             "transparency" not in output_image.info
         ), "Image should not have transparency info"
+
+    def test_png_preserves_alpha_for_transparent_solid_background(self):
+        """PNG output keeps alpha when the background color explicitly has alpha."""
+        config = ScreenshotConfig(
+            name="Transparent Alpha Test",
+            source_image=str(self.source_image_path),
+            output_size=(400, 800),
+            output_path=str(self.temp_dir / "transparent_alpha.png"),
+            background=GradientConfig(type="solid", colors=["#00000000"]),
+        )
+
+        result_path = self.generator.generate_screenshot(config)
+
+        output_image = Image.open(result_path)
+        assert output_image.mode == "RGBA"
+        assert output_image.getpixel((0, 0))[3] == 0
+        assert output_image.getpixel((200, 400))[3] == 255
+
+    def test_png_preserves_alpha_for_transparent_background_type(self):
+        """PNG output keeps alpha when using background type transparent."""
+        config = ScreenshotConfig(
+            name="Transparent Type Test",
+            source_image=str(self.source_image_path),
+            output_size=(400, 800),
+            output_path=str(self.temp_dir / "transparent_type.png"),
+            background=GradientConfig(type="transparent"),
+        )
+
+        result_path = self.generator.generate_screenshot(config)
+
+        output_image = Image.open(result_path)
+        assert output_image.mode == "RGBA"
+        assert output_image.getpixel((0, 0))[3] == 0
 
     def test_jpeg_has_no_alpha_channel(self):
         """Test that generated JPEG files don't have alpha channel."""

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -31,6 +31,25 @@ class TestBackgroundRenderer:
         pixel = self.canvas.getpixel((100, 100))
         assert pixel == (255, 0, 0, 255)  # Red
 
+    def test_solid_background_with_alpha(self):
+        """Test solid background rendering preserves color alpha."""
+        config = GradientConfig(type="solid", colors=["#00000000"])
+
+        self.renderer.render(config, self.canvas)
+
+        pixel = self.canvas.getpixel((100, 100))
+        assert pixel == (0, 0, 0, 0)
+
+    def test_transparent_background(self):
+        """Test transparent background clears the canvas alpha."""
+        self.canvas.paste(Image.new("RGBA", self.canvas.size, (255, 0, 0, 255)))
+        config = GradientConfig(type="transparent")
+
+        self.renderer.render(config, self.canvas)
+
+        pixel = self.canvas.getpixel((100, 100))
+        assert pixel == (255, 255, 255, 0)
+
     def test_linear_gradient(self):
         """Test linear gradient rendering."""
         config = GradientConfig(


### PR DESCRIPTION
## Summary
- Add `background.type: transparent` for explicit transparent PNG output.
- Preserve PNG alpha when a background color uses 8-digit hex alpha such as `#00000000`.
- Keep the existing App Store-safe RGB flattening for normal PNGs and all JPEGs.
- Document transparent backgrounds in README and YAML API docs.

Closes #25

## Tests
- `.venv/bin/pytest tests/test_config.py tests/test_renderers.py tests/test_generator.py -q`
- `.venv/bin/pytest tests/ -q --maxfail=3` currently hits sandbox socket restrictions in `tests/test_html_preview.py` (`PermissionError: [Errno 1] Operation not permitted`).