### PR TITLE
Fix #29: document and verify custom font support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,47 @@ Example:
 
 Use this file for objective layout facts only: element positions, occupied space, and real overlaps. Koubou does not interpret whether something is too small, too large, or aesthetically correct.
 
+## 🔤 Custom Fonts
+
+For standard YAML content screenshots, set `font_family` on a text item. The value can be either an installed system font name or a path to a `.ttf`, `.otf`, or `.ttc` file. Relative font paths are resolved from the YAML config file directory.
+
+```yaml
+screenshots:
+  welcome_screen:
+    content:
+      - type: "text"
+        content: "Welcome to Amazing App"
+        position: ["50%", "20%"]
+        size: 72
+        weight: "bold"
+        color: "#ffffff"
+        font_family: "assets/fonts/BrandDisplay-Bold.ttf"
+```
+
+For HTML template screenshots, use normal CSS font loading. Put the font next to the template, or expose it through `assets:`, then reference it with `@font-face`.
+
+```yaml
+screenshots:
+  hero:
+    template: "templates/hero.html"
+    assets:
+      brand_font: "assets/fonts/BrandDisplay-Bold.ttf"
+```
+
+```html
+<style>
+  @font-face {
+    font-family: "Brand Display";
+    src: url("{{brand_font}}") format("truetype");
+    font-weight: 700;
+  }
+
+  h1 {
+    font-family: "Brand Display", -apple-system, BlinkMacSystemFont, sans-serif;
+  }
+</style>
+```
+
 ## 🔄 Live Editing
 
 Real-time screenshot regeneration when your YAML configuration or assets change.

--- a/docs/yaml-api.md
+++ b/docs/yaml-api.md
@@ -302,7 +302,7 @@ Content items define the visual elements within each screenshot.
   gradient: object?          # Text gradient (see Gradient Configuration below)
 
   weight: string?            # "normal" or "bold" (default: "normal")
-  font_family: string?       # Font family name (default: "Arial")
+  font_family: string?       # System font name or .ttf/.otf/.ttc path (default: "Arial")
   alignment: string?         # "left", "center", "right" (default: "center")
                              # Also defines how position.x is interpreted:
                              # left=edge, center=midpoint, right=edge
@@ -350,6 +350,10 @@ When `min_size`, `max_width`, and `max_height` are all set, Koubou automatically
   weight: "bold"
   font_family: "assets/MyFont.ttf"
 ```
+
+`font_family` can be an installed system font name, such as `"Helvetica Neue"`,
+or a `.ttf`, `.otf`, or `.ttc` font file. Relative font file paths are resolved
+from the YAML config file directory.
 
 **How it works:**
 1. Start at `size` (e.g., 120px)

--- a/src/koubou/generator.py
+++ b/src/koubou/generator.py
@@ -128,6 +128,30 @@ def resolve_localized_asset(
         return asset
 
 
+def resolve_font_family(font_family: str, config_dir: Optional[Path] = None) -> str:
+    """Resolve project-local font paths while preserving system font names."""
+    if not font_family or not config_dir:
+        return font_family
+
+    font_path = Path(font_family)
+    if font_path.is_absolute():
+        return font_family
+
+    looks_like_path = (
+        "/" in font_family
+        or "\\" in font_family
+        or font_path.suffix.lower() in {".ttf", ".otf", ".ttc"}
+    )
+    if not looks_like_path:
+        return font_family
+
+    candidate = config_dir / font_path
+    if candidate.exists():
+        return str(candidate.resolve())
+
+    return font_family
+
+
 class ScreenshotGenerator:
     """Main class for generating screenshots with backgrounds, text, and frames."""
 
@@ -1395,7 +1419,10 @@ class ScreenshotGenerator:
                         position=position,
                         font_size=item.size or 24,
                         font_weight=getattr(item, "weight", "normal") or "normal",
-                        font_family=getattr(item, "font_family", "Arial") or "Arial",
+                        font_family=resolve_font_family(
+                            getattr(item, "font_family", "Arial") or "Arial",
+                            config_dir,
+                        ),
                         color=item.color,  # Don't default to black if gradient
                         # is provided
                         gradient=item.gradient,  # Pass gradient configuration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,36 @@ from koubou.config import GradientConfig, ScreenshotConfig, TextOverlay
 
 
 @pytest.fixture
+def system_font_file():
+    """Find a real local font file for custom-font integration tests."""
+    preferred = [
+        Path("/System/Library/Fonts/Supplemental/Arial.ttf"),
+        Path("/System/Library/Fonts/SFNS.ttf"),
+        Path("/Library/Fonts/Arial.ttf"),
+        Path("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"),
+        Path("/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf"),
+    ]
+    for path in preferred:
+        if path.exists():
+            return path
+
+    for root in [
+        Path("/System/Library/Fonts"),
+        Path("/Library/Fonts"),
+        Path("/usr/share/fonts"),
+    ]:
+        if not root.exists():
+            continue
+        for suffix in ("*.ttf", "*.otf", "*.ttc"):
+            try:
+                return next(root.rglob(suffix))
+            except StopIteration:
+                continue
+
+    pytest.skip("No local TrueType/OpenType font file available")
+
+
+@pytest.fixture
 def temp_dir():
     """Create a temporary directory for tests."""
     temp_dir = Path(tempfile.mkdtemp())

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -8,7 +8,7 @@ import pytest
 from PIL import Image
 
 from koubou.config import GradientConfig, ProjectConfig, ScreenshotConfig, TextOverlay
-from koubou.generator import ScreenshotGenerator
+from koubou.generator import ScreenshotGenerator, resolve_font_family
 
 
 class TestScreenshotGenerator:
@@ -643,6 +643,107 @@ class TestScreenshotGenerator:
             assert config.text_overlays[0].alignment == alignment
             assert config.text_overlays[0].anchor == expected_anchor
             assert config.text_overlays[0].position == (120, 80)
+
+    def test_resolve_font_family_resolves_project_local_font_path(self):
+        """Project-local font files should resolve relative to the YAML directory."""
+        font_path = self.temp_dir / "assets" / "BrandFont.ttf"
+        font_path.parent.mkdir()
+        font_path.write_bytes(b"test-font")
+
+        resolved = resolve_font_family("assets/BrandFont.ttf", self.temp_dir)
+
+        assert resolved == str(font_path.resolve())
+
+    def test_resolve_font_family_preserves_system_font_names(self):
+        """System font names should not be rewritten as paths."""
+        assert resolve_font_family("Helvetica Neue", self.temp_dir) == "Helvetica Neue"
+
+    def test_convert_to_screenshot_config_resolves_text_font_path(self):
+        """Content text font paths should be normalized before rendering."""
+        from koubou.config import ContentItem, ScreenshotDefinition
+
+        font_path = self.temp_dir / "assets" / "BrandFont.ttf"
+        font_path.parent.mkdir()
+        font_path.write_bytes(b"test-font")
+
+        screenshot_def = ScreenshotDefinition(
+            content=[
+                ContentItem(
+                    type="image",
+                    asset=str(self.source_image_path),
+                    position=("50%", "50%"),
+                ),
+                ContentItem(
+                    type="text",
+                    content="Custom font",
+                    position=("50%", "20%"),
+                    font_family="assets/BrandFont.ttf",
+                ),
+            ],
+            frame=False,
+        )
+
+        config = self.generator._convert_to_screenshot_config(
+            screenshot_def=screenshot_def,
+            device_frame=None,
+            default_background=None,
+            output_dir=str(self.temp_dir / "project_font_output"),
+            config_dir=self.temp_dir,
+            output_size=(1000, 800),
+        )
+
+        assert config is not None
+        assert config.text_overlays[0].font_family == str(font_path.resolve())
+
+    def test_project_generation_renders_yaml_text_with_project_local_font(
+        self, system_font_file
+    ):
+        """End-to-end YAML content generation should load a relative font file."""
+        from koubou.config import ContentItem, ProjectInfo, ScreenshotDefinition
+
+        font_dir = self.temp_dir / "assets" / "fonts"
+        font_dir.mkdir(parents=True)
+        font_path = font_dir / "BrandFont.ttf"
+        shutil.copyfile(system_font_file, font_path)
+
+        project_config = ProjectConfig(
+            project=ProjectInfo(
+                name="Custom Font YAML",
+                output_dir=str(self.temp_dir / "font_output"),
+                device="iPhone 15 Pro Portrait",
+                output_size=[400, 800],
+            ),
+            screenshots={
+                "custom_font": ScreenshotDefinition(
+                    content=[
+                        ContentItem(
+                            type="image",
+                            asset=str(self.source_image_path),
+                            position=("50%", "60%"),
+                            scale=0.5,
+                        ),
+                        ContentItem(
+                            type="text",
+                            content="Custom Font",
+                            position=("50%", "20%"),
+                            size=48,
+                            color="#ffffff",
+                            font_family="assets/fonts/BrandFont.ttf",
+                        ),
+                    ],
+                    frame=False,
+                )
+            },
+        )
+
+        results = self.generator.generate_project(
+            project_config, config_dir=self.temp_dir
+        )
+
+        assert len(results) == 1
+        assert results[0].exists()
+        generated = Image.open(results[0])
+        assert generated.size == (400, 800)
 
     def test_position_source_image_respects_left_alignment(self):
         """Image alignment should control horizontal placement for project assets."""

--- a/tests/test_html_renderer.py
+++ b/tests/test_html_renderer.py
@@ -339,6 +339,79 @@ class TestHtmlRenderer:
         assert layout["elements"][0]["role"] == "headline"
         assert layout["overlaps"] == []
 
+    def test_project_generate_with_template_custom_font_asset(
+        self, temp_dir, system_font_file
+    ):
+        """End-to-end: HTML templates should load custom fonts via assets."""
+        from koubou.generator import ScreenshotGenerator
+
+        font_dir = temp_dir / "assets" / "fonts"
+        font_dir.mkdir(parents=True)
+        font_path = font_dir / "BrandFont.ttf"
+        shutil.copyfile(system_font_file, font_path)
+
+        template = temp_dir / "hero.html"
+        template.write_text(
+            """<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    @font-face {
+      font-family: "Brand Display";
+      src: url("{{brand_font}}") format("truetype");
+      font-weight: 700;
+    }
+    body {
+      margin: 0;
+      background: #111827;
+      width: 100vw;
+      height: 100vh;
+      display: grid;
+      place-items: center;
+    }
+    h1 {
+      color: white;
+      font-family: "Brand Display", sans-serif;
+      font-size: 64px;
+    }
+  </style>
+</head>
+<body>
+  <h1 data-kou-id="headline" data-kou-role="headline">Custom Font</h1>
+</body>
+</html>""",
+            encoding="utf-8",
+        )
+
+        output_dir = temp_dir / "output"
+        config = ProjectConfig(
+            project=ProjectInfo(
+                name="TestHTMLFont",
+                output_dir=str(output_dir),
+                device="iPhone 16 Pro - Black Titanium - Portrait",
+                output_size=[400, 800],
+            ),
+            screenshots={
+                "hero": ScreenshotDefinition(
+                    template="hero.html",
+                    assets={"brand_font": "assets/fonts/BrandFont.ttf"},
+                    frame=False,
+                ),
+            },
+        )
+
+        generator = ScreenshotGenerator()
+        results = generator.generate_project(config, config_dir=temp_dir)
+
+        assert len(results) == 1
+        assert results[0].exists()
+
+        img = Image.open(results[0])
+        assert img.size == (400, 800)
+
+        layout = json.loads(results[0].with_suffix(".layout.json").read_text())
+        assert layout["elements"][0]["id"] == "headline"
+
     def test_render_staged_with_layout_returns_empty_manifest_without_annotations(
         self, temp_dir, renderer
     ):
@@ -579,3 +652,48 @@ class TestHtmlTemplateAssetLocalization:
         assert prepared.assets["app_screenshot.png"] == str(
             (raw_dir / "fallback.png").resolve()
         )
+
+    def test_prepare_html_screenshot_exposes_font_asset_to_template(
+        self, temp_dir, system_font_file
+    ):
+        from koubou.renderers.html_staging import stage_html_workspace
+
+        generator = self._make_generator(temp_dir)
+
+        font_dir = temp_dir / "assets" / "fonts"
+        font_dir.mkdir(parents=True)
+        font_path = font_dir / "BrandFont.ttf"
+        shutil.copyfile(system_font_file, font_path)
+
+        template = temp_dir / "hero.html"
+        template.write_text(
+            """<html><head><style>
+@font-face {
+  font-family: "Brand Display";
+  src: url("{{brand_font}}") format("truetype");
+}
+</style></head><body>Font asset</body></html>""",
+            encoding="utf-8",
+        )
+
+        screenshot = ScreenshotDefinition(
+            template="hero.html",
+            assets={"brand_font": "assets/fonts/BrandFont.ttf"},
+            frame=False,
+        )
+
+        prepared = generator.prepare_html_screenshot(screenshot, temp_dir)
+
+        assert prepared.variables["brand_font"] == "brand_font.ttf"
+        assert prepared.assets["brand_font.ttf"] == str(font_path.resolve())
+
+        workspace_dir = temp_dir / "workspace"
+        staged_index = stage_html_workspace(
+            template_path=prepared.template_path,
+            variables=prepared.variables,
+            destination_dir=workspace_dir,
+            assets=prepared.assets,
+        )
+
+        assert (workspace_dir / "brand_font.ttf").exists()
+        assert 'url("brand_font.ttf")' in staged_index.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Document how to use custom fonts in standard YAML content screenshots with `font_family`
- Resolve relative `.ttf`, `.otf`, and `.ttc` font paths from the YAML config directory before rendering
- Document HTML template font loading with `assets` and `@font-face`
- Add YAML and HTML tests that copy a real local font file, render/generate screenshots, and verify asset staging

Closes #29

## Tests
- `.venv/bin/pytest tests/test_generator.py tests/test_html_renderer.py -k "font or custom_font or template_custom_font or exposes_font" -q`
- `.venv/bin/pytest tests/test_generator.py tests/test_html_renderer.py -q`
- `.venv/bin/pytest -q`